### PR TITLE
Enhance Expo Crisp SDK types and module documentation

### DIFF
--- a/src/ExpoCrispSdk.types.ts
+++ b/src/ExpoCrispSdk.types.ts
@@ -1,65 +1,185 @@
 /**
  * Crisp SDK Types
+ *
+ * Type definitions for the Expo Crisp SDK.
+ * These types are used to configure user information, company data,
+ * and session events in the Crisp chat widget.
+ *
+ * @packageDocumentation
  */
 
 /**
- * Colors available for session events
+ * Colors available for session events.
+ * Used to visually categorize events in the Crisp dashboard timeline.
+ *
+ * @example
+ * ```typescript
+ * import { CrispSessionEventColors } from "expo-crisp-sdk";
+ *
+ * // Use GREEN for successful actions
+ * ExpoCrispSdk.pushSessionEvent("Purchase completed", CrispSessionEventColors.GREEN);
+ *
+ * // Use RED for errors or issues
+ * ExpoCrispSdk.pushSessionEvent("Payment failed", CrispSessionEventColors.RED);
+ * ```
  */
 export enum CrispSessionEventColors {
+  /** Red - Use for errors, failures, or critical events */
   RED = 0,
+  /** Orange - Use for warnings or attention-needed events */
   ORANGE = 1,
+  /** Yellow - Use for informational highlights */
   YELLOW = 2,
+  /** Green - Use for success, completion, or positive events */
   GREEN = 3,
+  /** Blue - Use for informational or neutral events */
   BLUE = 4,
+  /** Purple - Use for special or premium-related events */
   PURPLE = 5,
+  /** Pink - Use for social or engagement events */
   PINK = 6,
+  /** Brown - Use for historical or archive events */
   BROWN = 7,
+  /** Grey - Use for secondary or low-priority events */
   GREY = 8,
+  /** Black - Use for system or administrative events */
   BLACK = 9,
 }
 
 /**
- * Employment information for a user
+ * Employment information for a user within their company.
+ *
+ * @example
+ * ```typescript
+ * const employment: Employment = {
+ *   title: "Senior Software Engineer",
+ *   role: "Engineering"
+ * };
+ * ```
  */
 export interface Employment {
-  /** Job title (e.g., "Software Engineer") */
+  /**
+   * Job title of the user.
+   * @example "Software Engineer", "Product Manager", "CEO"
+   */
   title?: string;
-  /** Job role (e.g., "Engineering") */
+
+  /**
+   * Job role or department.
+   * @example "Engineering", "Sales", "Marketing", "Support"
+   */
   role?: string;
 }
 
 /**
- * Geolocation information
+ * Geolocation information for a company or user.
+ *
+ * @example
+ * ```typescript
+ * const location: Geolocation = {
+ *   country: "France",
+ *   city: "Paris"
+ * };
+ * ```
  */
 export interface Geolocation {
-  /** Country name or code */
+  /**
+   * Country name or ISO country code.
+   * @example "France", "United States", "FR", "US"
+   */
   country?: string;
-  /** City name */
+
+  /**
+   * City name.
+   * @example "Paris", "New York", "London"
+   */
   city?: string;
 }
 
 /**
- * Company information for a user
+ * Company information for a user.
+ * Associates the user with their organization in the Crisp dashboard.
+ *
+ * @example
+ * ```typescript
+ * import ExpoCrispSdk from "expo-crisp-sdk";
+ *
+ * ExpoCrispSdk.setUserCompany({
+ *   name: "Acme Corporation",
+ *   url: "https://acme.com",
+ *   companyDescription: "Leading provider of innovative solutions",
+ *   employment: {
+ *     title: "Software Engineer",
+ *     role: "Engineering"
+ *   },
+ *   geolocation: {
+ *     country: "France",
+ *     city: "Paris"
+ *   }
+ * });
+ * ```
  */
 export interface Company {
-  /** Company name (required) */
+  /**
+   * Company name (required).
+   * This is the only required field for company information.
+   */
   name: string;
-  /** Company website URL */
+
+  /**
+   * Company website URL.
+   * Should be a valid URL including the protocol (https://).
+   * @example "https://acme.com"
+   */
   url?: string;
-  /** Company description */
+
+  /**
+   * Brief description of the company.
+   * Helps operators understand the user's organization context.
+   */
   companyDescription?: string;
-  /** User's employment details within the company */
+
+  /**
+   * User's employment details within the company.
+   * Includes job title and role/department.
+   */
   employment?: Employment;
-  /** Company location */
+
+  /**
+   * Company's geographic location.
+   * Includes country and city information.
+   */
   geolocation?: Geolocation;
 }
 
 /**
- * Session event with name and color
+ * Session event to track in the user's chat timeline.
+ * Events are visible to operators and help understand user actions.
+ *
+ * @example
+ * ```typescript
+ * import ExpoCrispSdk, { CrispSessionEventColors, SessionEvent } from "expo-crisp-sdk";
+ *
+ * const events: SessionEvent[] = [
+ *   { name: "Viewed pricing page", color: CrispSessionEventColors.BLUE },
+ *   { name: "Started free trial", color: CrispSessionEventColors.GREEN },
+ *   { name: "Upgraded to Pro", color: CrispSessionEventColors.PURPLE }
+ * ];
+ *
+ * ExpoCrispSdk.pushSessionEvents(events);
+ * ```
  */
 export interface SessionEvent {
-  /** Event name */
+  /**
+   * Event name describing the action.
+   * Keep it concise but descriptive.
+   * @example "Purchase completed", "Feature activated", "Error encountered"
+   */
   name: string;
-  /** Event color for display */
+
+  /**
+   * Event color for visual categorization in the dashboard.
+   * Choose a color that reflects the nature of the event.
+   */
   color: CrispSessionEventColors;
 }

--- a/src/ExpoCrispSdkModule.ts
+++ b/src/ExpoCrispSdkModule.ts
@@ -9,41 +9,209 @@ import type {
 type ExpoCrispSdkEvents = Record<string, never>;
 
 declare class ExpoCrispSdkModule extends NativeModule<ExpoCrispSdkEvents> {
+  // ============================================================================
   // Configuration
+  // ============================================================================
+
+  /**
+   * Initialize the Crisp SDK with your website ID.
+   * Must be called once at app startup before using any other methods.
+   *
+   * @param websiteId - Your Website ID from the Crisp Dashboard
+   * @see https://docs.crisp.chat/guides/chatbox-sdks/ios-sdk/#configure-crisp
+   */
   configure(websiteId: string): void;
+
+  /**
+   * Set a token for session persistence across app reinstalls and devices.
+   * Use this to maintain chat history when a user logs in.
+   *
+   * @param tokenId - Unique identifier (e.g., user ID), or `null` to clear
+   * @example
+   * // On login
+   * ExpoCrispSdk.setTokenId(user.id);
+   * // On logout
+   * ExpoCrispSdk.setTokenId(null);
+   */
   setTokenId(tokenId: string | null): void;
 
+  // ============================================================================
   // User Information
+  // ============================================================================
+
+  /**
+   * Set the user's email address for identification in the chat.
+   *
+   * @param email - User's email address
+   * @param signature - Optional HMAC-SHA256 signature for email verification
+   * @see https://docs.crisp.chat/guides/chatbox-sdks/ios-sdk/#set-user-email
+   */
   setUserEmail(email: string, signature?: string | null): void;
+
+  /**
+   * Set the user's display name shown in the chat.
+   *
+   * @param name - User's nickname or display name
+   */
   setUserNickname(name: string): void;
+
+  /**
+   * Set the user's phone number.
+   *
+   * @param phone - Phone number (E.164 format recommended, e.g., "+1234567890")
+   */
   setUserPhone(phone: string): void;
+
+  /**
+   * Set the user's company information.
+   *
+   * @param company - Company details including name, URL, employment, and location
+   * @example
+   * ExpoCrispSdk.setUserCompany({
+   *   name: "Acme Inc",
+   *   url: "https://acme.com",
+   *   employment: { title: "Engineer", role: "Development" },
+   *   geolocation: { country: "France", city: "Paris" }
+   * });
+   */
   setUserCompany(company: Company): void;
+
+  /**
+   * Set the user's avatar image.
+   *
+   * @param url - URL to the user's avatar image
+   */
   setUserAvatar(url: string): void;
 
+  // ============================================================================
   // Session Data
+  // ============================================================================
+
+  /**
+   * Store a custom string value in the session data.
+   * Visible to operators in the Crisp dashboard.
+   *
+   * @param key - Data key
+   * @param value - String value to store
+   */
   setSessionString(key: string, value: string): void;
+
+  /**
+   * Store a custom boolean value in the session data.
+   * Visible to operators in the Crisp dashboard.
+   *
+   * @param key - Data key
+   * @param value - Boolean value to store
+   */
   setSessionBool(key: string, value: boolean): void;
+
+  /**
+   * Store a custom integer value in the session data.
+   * Visible to operators in the Crisp dashboard.
+   *
+   * @param key - Data key
+   * @param value - Integer value to store
+   */
   setSessionInt(key: string, value: number): void;
+
+  /**
+   * Set a single segment to categorize the user.
+   * Segments help organize users in the Crisp dashboard.
+   *
+   * @param segment - Segment name (e.g., "premium", "trial")
+   */
   setSessionSegment(segment: string): void;
+
+  /**
+   * Set multiple segments to categorize the user.
+   *
+   * @param segments - Array of segment names
+   * @param overwrite - If true, replaces existing segments; if false, appends
+   */
   setSessionSegments(segments: string[], overwrite?: boolean): void;
+
+  /**
+   * Get the current session identifier.
+   *
+   * @returns Promise resolving to the session ID, or null if not available
+   */
   getSessionIdentifier(): Promise<string | null>;
 
+  // ============================================================================
   // Events
+  // ============================================================================
+
+  /**
+   * Track a single event in the user's chat timeline.
+   * Events are visible to operators and help understand user actions.
+   *
+   * @param name - Event name (e.g., "Purchase completed")
+   * @param color - Event color for visual categorization
+   * @example
+   * ExpoCrispSdk.pushSessionEvent("Checkout", CrispSessionEventColors.GREEN);
+   */
   pushSessionEvent(name: string, color: CrispSessionEventColors): void;
+
+  /**
+   * Track multiple events in the user's chat timeline.
+   *
+   * @param events - Array of events with name and color
+   * @example
+   * ExpoCrispSdk.pushSessionEvents([
+   *   { name: "Added to cart", color: CrispSessionEventColors.BLUE },
+   *   { name: "Checkout started", color: CrispSessionEventColors.ORANGE }
+   * ]);
+   */
   pushSessionEvents(events: SessionEvent[]): void;
 
+  // ============================================================================
   // Session Management
+  // ============================================================================
+
+  /**
+   * Reset the current chat session.
+   * Clears all session data and starts a fresh conversation.
+   * Typically called on user logout.
+   */
   resetSession(): void;
 
+  // ============================================================================
   // UI
+  // ============================================================================
+
+  /**
+   * Open the Crisp chat widget.
+   * Presents the chat interface as a modal.
+   */
   show(): void;
+
+  /**
+   * Open the helpdesk search interface.
+   * Allows users to search through your knowledge base articles.
+   */
   searchHelpdesk(): void;
+
+  /**
+   * Open a specific helpdesk article.
+   *
+   * @param id - Article slug or identifier
+   * @param locale - Article locale (e.g., "en", "fr")
+   * @param title - Optional article title for display
+   * @param category - Optional category name for display
+   */
   openHelpdeskArticle(
     id: string,
     locale: string,
     title?: string | null,
     category?: string | null
   ): void;
+
+  /**
+   * Trigger an automated bot scenario.
+   * Starts a predefined conversation flow configured in the Crisp dashboard.
+   *
+   * @param scenarioId - The scenario identifier from the Crisp dashboard
+   */
   runBotScenario(scenarioId: string): void;
 }
 


### PR DESCRIPTION
## Summary
Add comprehensive JSDoc documentation to SDK types and module for improved IDE autocompletion and developer experience.

## Main changes
- Add detailed JSDoc comments with `@param`, `@example`, and `@see` tags to all 18 methods in `ExpoCrispSdkModule.ts`
- Enhance type definitions in `ExpoCrispSdk.types.ts` with usage examples and detailed property descriptions
- Document `CrispSessionEventColors` enum with semantic guidance for each color
- Add `@packageDocumentation` tag and module-level documentation
- Organize module methods into logical sections (Configuration, User Information, Session Data, Events, UI)