### PR TITLE
Add getSDKVersion function to retrieve SDK version

### DIFF
--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -1,4 +1,4 @@
-import Crisp, { useCrispEvents } from "expo-crisp-sdk";
+import Crisp, { useCrispEvents, getSDKVersion } from "expo-crisp-sdk";
 import { useEffect, useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -11,6 +11,8 @@ export default function HomeScreen() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [chatStatus, setChatStatus] = useState<"closed" | "open">("closed");
   const [sessionId, setSessionId] = useState<string | null>(null);
+
+  console.log("SDK Version:", getSDKVersion());
 
   // Test Events Callbacks
   useCrispEvents({

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./ExpoCrispSdk.types";
 export { default } from "./ExpoCrispSdkModule";
 export type { CrispEventCallbacks } from "./useCrispEvents";
 export { useCrispEvents } from "./useCrispEvents";
+export { getSDKVersion } from "./version";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,13 @@
+import { version } from "../package.json";
+
+/**
+ * Returns the version of the expo-crisp-sdk package.
+ *
+ * @returns The SDK version string (e.g., "0.1.0")
+ * @example
+ * const version = getSDKVersion();
+ * console.log(version); // "0.1.0"
+ */
+export function getSDKVersion(): string {
+  return version;
+}


### PR DESCRIPTION
## Summary
Add `getSDKVersion()` function to expose the SDK version from package.json at runtime.

## Main changes
- Add `src/version.ts` with `getSDKVersion()` function that reads version from package.json
- Export `getSDKVersion` from main entry point in `src/index.ts`
- Add usage example in example app's HomeScreen component