### PR TITLE
dx: replace default export with named wrapper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,11 @@ Configure the SDK at app startup with your Website ID:
 
 ```typescript
 import { useEffect } from "react";
-import Crisp from "expo-crisp-sdk";
+import { configure } from "expo-crisp-sdk";
 
 export default function App() {
   useEffect(() => {
-    Crisp.configure("YOUR_WEBSITE_ID");
+    configure("YOUR_WEBSITE_ID");
   }, []);
 
   return (
@@ -277,16 +277,16 @@ In coexistence mode, the plugin:
 **JS API for coexistence mode:**
 
 ```typescript
-import Crisp from "expo-crisp-sdk";
+import { registerPushToken, isCrispPushNotification, setShouldPromptForNotificationPermission } from "expo-crisp-sdk";
 
 // Register a push token obtained from your notification system
-Crisp.registerPushToken(expoPushToken);
+registerPushToken(expoPushToken);
 
 // Check if a notification payload is from Crisp
-const isCrisp = Crisp.isCrispPushNotification(notificationData);
+const isCrisp = isCrispPushNotification(notificationData);
 
 // Control whether Crisp auto-prompts for notification permissions (iOS only)
-Crisp.setShouldPromptForNotificationPermission(false);
+setShouldPromptForNotificationPermission(false);
 ```
 
 **Listen for Crisp notifications in the foreground (iOS only):**
@@ -317,11 +317,11 @@ useCrispEvents({
 Display the Crisp chat widget:
 
 ```typescript
-import Crisp from "expo-crisp-sdk";
+import { show } from "expo-crisp-sdk";
 
 function ChatButton() {
   const openChat = () => {
-    Crisp.show();
+    show();
   };
 
   return <Button title="Chat with us" onPress={openChat} />;
@@ -333,18 +333,21 @@ function ChatButton() {
 Set user information to personalize the chat experience:
 
 ```typescript
-import Crisp from "expo-crisp-sdk";
+import {
+  setUserEmail, setUserNickname, setUserPhone, setUserAvatar,
+  setUserCompany, setTokenId, resetSession,
+} from "expo-crisp-sdk";
 
 // After user logs in
 function identifyUser(user) {
   // Basic identification
-  Crisp.setUserEmail(user.email);
-  Crisp.setUserNickname(user.name);
-  Crisp.setUserPhone(user.phone); // E.164 format recommended: "+1234567890"
-  Crisp.setUserAvatar(user.avatarUrl);
+  setUserEmail(user.email);
+  setUserNickname(user.name);
+  setUserPhone(user.phone); // E.164 format recommended: "+1234567890"
+  setUserAvatar(user.avatarUrl);
 
   // Set company information
-  Crisp.setUserCompany({
+  setUserCompany({
     name: "Acme Corporation",
     url: "https://acme.com",
     companyDescription: "Leading provider of innovative solutions",
@@ -359,13 +362,13 @@ function identifyUser(user) {
   });
 
   // Enable session persistence across devices
-  Crisp.setTokenId(user.id);
+  setTokenId(user.id);
 }
 
 // On logout
 function onLogout() {
-  Crisp.setTokenId(null);
-  Crisp.resetSession();
+  setTokenId(null);
+  resetSession();
 }
 ```
 
@@ -374,24 +377,27 @@ function onLogout() {
 Store custom data visible to operators in the Crisp dashboard:
 
 ```typescript
-import Crisp from "expo-crisp-sdk";
+import {
+  setSessionString, setSessionBool, setSessionInt,
+  setSessionSegment, setSessionSegments, getSessionIdentifier,
+} from "expo-crisp-sdk";
 
 // Store different data types
-Crisp.setSessionString("plan", "premium");
-Crisp.setSessionBool("verified", true);
-Crisp.setSessionInt("loginCount", 42);
+setSessionString("plan", "premium");
+setSessionBool("verified", true);
+setSessionInt("loginCount", 42);
 
 // Categorize users with segments
-Crisp.setSessionSegment("vip");
+setSessionSegment("vip");
 
 // Or set multiple segments at once
-Crisp.setSessionSegments(["premium", "early-adopter", "beta-tester"]);
+setSessionSegments(["premium", "early-adopter", "beta-tester"]);
 
 // Replace all existing segments
-Crisp.setSessionSegments(["enterprise"], true);
+setSessionSegments(["enterprise"], true);
 
 // Get the current session identifier
-const sessionId = await Crisp.getSessionIdentifier();
+const sessionId = await getSessionIdentifier();
 console.log("Session ID:", sessionId);
 ```
 
@@ -400,14 +406,14 @@ console.log("Session ID:", sessionId);
 Track user actions in the chat timeline:
 
 ```typescript
-import Crisp, { CrispSessionEventColors } from "expo-crisp-sdk";
+import { pushSessionEvent, pushSessionEvents, CrispSessionEventColors } from "expo-crisp-sdk";
 
 // Track a single event
-Crisp.pushSessionEvent("Purchase completed", CrispSessionEventColors.GREEN);
-Crisp.pushSessionEvent("Payment failed", CrispSessionEventColors.RED);
+pushSessionEvent("Purchase completed", CrispSessionEventColors.GREEN);
+pushSessionEvent("Payment failed", CrispSessionEventColors.RED);
 
 // Track multiple events at once
-Crisp.pushSessionEvents([
+pushSessionEvents([
   { name: "Viewed pricing page", color: CrispSessionEventColors.BLUE },
   { name: "Started free trial", color: CrispSessionEventColors.GREEN },
   { name: "Upgraded to Pro", color: CrispSessionEventColors.PURPLE },
@@ -421,7 +427,7 @@ Subscribe to SDK events using the `useCrispEvents` hook:
 ```typescript
 import { useState } from "react";
 import { View, Button } from "react-native";
-import Crisp, { useCrispEvents } from "expo-crisp-sdk";
+import { show, useCrispEvents } from "expo-crisp-sdk";
 
 function ChatScreen() {
   const [unreadCount, setUnreadCount] = useState(0);
@@ -452,7 +458,7 @@ function ChatScreen() {
     <View>
       <Button
         title={`Open Chat (${unreadCount})`}
-        onPress={() => Crisp.show()}
+        onPress={() => show()}
       />
     </View>
   );
@@ -464,16 +470,16 @@ function ChatScreen() {
 Display messages programmatically in the chat:
 
 ```typescript
-import Crisp from "expo-crisp-sdk";
+import { showMessage } from "expo-crisp-sdk";
 
 // Simple text message
-Crisp.showMessage({
+showMessage({
   type: "text",
   text: "Hello! How can I help you today?",
 });
 
 // File attachment
-Crisp.showMessage({
+showMessage({
   type: "file",
   url: "https://example.com/document.pdf",
   name: "Document.pdf",
@@ -481,14 +487,14 @@ Crisp.showMessage({
 });
 
 // Animation (GIF)
-Crisp.showMessage({
+showMessage({
   type: "animation",
   url: "https://example.com/celebration.gif",
   mimeType: "image/gif",
 });
 
 // Audio message
-Crisp.showMessage({
+showMessage({
   type: "audio",
   url: "https://example.com/voice-note.mp3",
   mimeType: "audio/mpeg",
@@ -496,7 +502,7 @@ Crisp.showMessage({
 });
 
 // Picker for user choice
-Crisp.showMessage({
+showMessage({
   type: "picker",
   id: "satisfaction",
   text: "How satisfied are you with our service?",
@@ -508,7 +514,7 @@ Crisp.showMessage({
 });
 
 // Field for user input
-Crisp.showMessage({
+showMessage({
   type: "field",
   id: "email",
   text: "What's your email address?",
@@ -517,7 +523,7 @@ Crisp.showMessage({
 });
 
 // Carousel with multiple items
-Crisp.showMessage({
+showMessage({
   type: "carousel",
   text: "Check out our products",
   targets: [
@@ -542,18 +548,18 @@ Crisp.showMessage({
 Access your knowledge base:
 
 ```typescript
-import Crisp from "expo-crisp-sdk";
+import { searchHelpdesk, openHelpdeskArticle } from "expo-crisp-sdk";
 
 // Open helpdesk search
-Crisp.searchHelpdesk();
+searchHelpdesk();
 
 // Open a specific article
-Crisp.openHelpdeskArticle(
-  "getting-started", // Article slug
-  "en", // Locale
-  "Getting Started", // Optional: Display title
-  "Onboarding" // Optional: Category name
-);
+openHelpdeskArticle({
+  id: "getting-started",
+  locale: "en",
+  title: "Getting Started",    // Optional
+  category: "Onboarding",      // Optional
+});
 ```
 
 ### Bot Scenarios
@@ -561,10 +567,10 @@ Crisp.openHelpdeskArticle(
 Trigger automated conversation flows:
 
 ```typescript
-import Crisp from "expo-crisp-sdk";
+import { runBotScenario } from "expo-crisp-sdk";
 
 // Start a bot scenario configured in your Crisp dashboard
-Crisp.runBotScenario("welcome-flow");
+runBotScenario("welcome-flow");
 ```
 
 ### Debug Logging
@@ -572,10 +578,10 @@ Crisp.runBotScenario("welcome-flow");
 Enable native SDK logging to help debug integration issues:
 
 ```typescript
-import Crisp, { CrispLogLevel, useCrispEvents } from "expo-crisp-sdk";
+import { setLogLevel, CrispLogLevel, useCrispEvents } from "expo-crisp-sdk";
 
 // Set the minimum log level (default: WARN)
-Crisp.setLogLevel(CrispLogLevel.DEBUG);
+setLogLevel(CrispLogLevel.DEBUG);
 
 // Listen to log messages from the native SDK
 useCrispEvents({
@@ -656,7 +662,7 @@ Available log levels (from most to least verbose):
 | ---------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------- | ------ |
 | `show()`                                             | Open the Crisp chat widget.         | -                                                                               | `void` |
 | `searchHelpdesk()`                                   | Open the helpdesk search interface. | -                                                                               | `void` |
-| `openHelpdeskArticle(id, locale, title?, category?)` | Open a specific helpdesk article.   | `id: string, locale: string, title?: string \| null, category?: string \| null` | `void` |
+| `openHelpdeskArticle(options)` | Open a specific helpdesk article.   | `options: HelpdeskArticleOptions` | `void` |
 | `runBotScenario(scenarioId)`                         | Trigger an automated bot scenario.  | `scenarioId: string`                                                            | `void` |
 
 ### Push Notification Methods (Coexistence Mode)

--- a/bare-example/App.tsx
+++ b/bare-example/App.tsx
@@ -1,20 +1,24 @@
-import Crisp, {
+import {
   type CrispLogEntry,
   CrispLogLevel,
+  configure,
   getSDKVersion,
   type PushNotificationPayload,
+  resetSession,
+  setLogLevel,
+  setShouldPromptForNotificationPermission,
+  setTokenId,
+  setUserCompany,
+  setUserEmail,
+  setUserNickname,
+  setUserPhone,
+  show,
+  showMessage,
   useCrispEvents,
-} from 'expo-crisp-sdk';
-import { useEffect, useState } from 'react';
-import {
-  Alert,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
-import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+} from "expo-crisp-sdk";
+import { useEffect, useState } from "react";
+import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 
 // 1. Get your Website ID from https://app.crisp.chat/settings/websites/
 const WEBSITE_ID = process.env.EXPO_PUBLIC_CRISP_WEBSITE_ID!;
@@ -25,100 +29,93 @@ let logIdCounter = 0;
 
 const getLogLevelName = (level: CrispLogLevel): string => {
   const names: Record<CrispLogLevel, string> = {
-    [CrispLogLevel.VERBOSE]: 'VERBOSE',
-    [CrispLogLevel.DEBUG]: 'DEBUG',
-    [CrispLogLevel.INFO]: 'INFO',
-    [CrispLogLevel.WARN]: 'WARN',
-    [CrispLogLevel.ERROR]: 'ERROR',
-    [CrispLogLevel.ASSERT]: 'ASSERT',
+    [CrispLogLevel.VERBOSE]: "VERBOSE",
+    [CrispLogLevel.DEBUG]: "DEBUG",
+    [CrispLogLevel.INFO]: "INFO",
+    [CrispLogLevel.WARN]: "WARN",
+    [CrispLogLevel.ERROR]: "ERROR",
+    [CrispLogLevel.ASSERT]: "ASSERT",
   };
-  return names[level] ?? 'UNKNOWN';
+  return names[level] ?? "UNKNOWN";
 };
 
 function HomeScreen() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [chatStatus, setChatStatus] = useState<'closed' | 'open'>('closed');
+  const [chatStatus, setChatStatus] = useState<"closed" | "open">("closed");
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [logs, setLogs] = useState<LogEntryWithId[]>([]);
-  const [currentLogLevel, setCurrentLogLevel] = useState<CrispLogLevel>(
-    CrispLogLevel.DEBUG,
-  );
-  const [lastNotification, setLastNotification] =
-    useState<PushNotificationPayload | null>(null);
+  const [currentLogLevel, setCurrentLogLevel] = useState<CrispLogLevel>(CrispLogLevel.DEBUG);
+  const [lastNotification, setLastNotification] = useState<PushNotificationPayload | null>(null);
 
-  console.log('SDK Version:', getSDKVersion());
+  console.log("SDK Version:", getSDKVersion());
 
   useCrispEvents({
-    onSessionLoaded: id => {
-      console.log('[Crisp] Session loaded:', id);
+    onSessionLoaded: (id) => {
+      console.log("[Crisp] Session loaded:", id);
       setSessionId(id);
     },
     onChatOpened: () => {
-      console.log('[Crisp] Chat opened');
-      setChatStatus('open');
+      console.log("[Crisp] Chat opened");
+      setChatStatus("open");
     },
     onChatClosed: () => {
-      console.log('[Crisp] Chat closed');
-      setChatStatus('closed');
+      console.log("[Crisp] Chat closed");
+      setChatStatus("closed");
     },
-    onMessageSent: message => {
-      console.log('[Crisp] Message sent:', message);
+    onMessageSent: (message) => {
+      console.log("[Crisp] Message sent:", message);
     },
-    onMessageReceived: message => {
-      console.log('[Crisp] Message received:', message);
+    onMessageReceived: (message) => {
+      console.log("[Crisp] Message received:", message);
     },
-    onPushNotificationReceived: notification => {
-      console.log('[Crisp] Push notification received:', notification);
+    onPushNotificationReceived: (notification) => {
+      console.log("[Crisp] Push notification received:", notification);
       setLastNotification(notification);
     },
-    onLogReceived: log => {
-      console.log(
-        `[Crisp Log] [${getLogLevelName(log.level)}] ${log.tag}: ${
-          log.message
-        }`,
-      );
+    onLogReceived: (log) => {
+      console.log(`[Crisp Log] [${getLogLevelName(log.level)}] ${log.tag}: ${log.message}`);
       const logWithId: LogEntryWithId = {
         ...log,
         id: `log-${++logIdCounter}`,
       };
-      setLogs(prev => [...prev.slice(-19), logWithId]);
+      setLogs((prev) => [...prev.slice(-19), logWithId]);
     },
   });
 
   useEffect(() => {
-    if (!WEBSITE_ID || WEBSITE_ID === 'YOUR_WEBSITE_ID') {
+    if (!WEBSITE_ID || WEBSITE_ID === "YOUR_WEBSITE_ID") {
       Alert.alert(
-        'Configuration Required',
-        'Please set your Crisp Website ID in App.tsx (WEBSITE_ID constant)',
+        "Configuration Required",
+        "Please set your Crisp Website ID in App.tsx (WEBSITE_ID constant)",
       );
       return;
     }
-    Crisp.configure(WEBSITE_ID);
-    Crisp.setLogLevel(CrispLogLevel.DEBUG);
+    configure(WEBSITE_ID);
+    setLogLevel(CrispLogLevel.DEBUG);
   }, []);
 
   const handleSetLogLevel = (level: CrispLogLevel) => {
-    Crisp.setLogLevel(level);
+    setLogLevel(level);
     setCurrentLogLevel(level);
     setLogs([]);
   };
 
   const handleLogin = () => {
-    Crisp.setTokenId('bare-example-token-001');
-    Crisp.setUserEmail('test@bareexample.com');
-    Crisp.setUserNickname('Bare Example User');
-    Crisp.setUserPhone('+33600000000');
-    Crisp.setUserCompany({
-      name: 'Test Company',
-      url: 'https://example.com',
-      companyDescription: 'Bare Workflow Test',
+    setTokenId("bare-example-token-001");
+    setUserEmail("test@bareexample.com");
+    setUserNickname("Bare Example User");
+    setUserPhone("+33600000000");
+    setUserCompany({
+      name: "Test Company",
+      url: "https://example.com",
+      companyDescription: "Bare Workflow Test",
       employment: {
-        title: 'Developer',
-        role: 'Engineering',
+        title: "Developer",
+        role: "Engineering",
       },
       geolocation: {
-        city: 'Paris',
-        country: 'FR',
+        city: "Paris",
+        country: "FR",
       },
     });
 
@@ -126,8 +123,8 @@ function HomeScreen() {
   };
 
   const handleLogout = () => {
-    Crisp.setTokenId(null);
-    Crisp.resetSession();
+    setTokenId(null);
+    resetSession();
     setIsLoggedIn(false);
   };
 
@@ -151,61 +148,49 @@ function HomeScreen() {
             <Text style={styles.buttonText}>Login (Set User Info)</Text>
           </Pressable>
         ) : (
-          <Pressable
-            style={[styles.button, styles.logoutButton]}
-            onPress={handleLogout}
-          >
+          <Pressable style={[styles.button, styles.logoutButton]} onPress={handleLogout}>
             <Text style={styles.buttonText}>Logout (Reset Session)</Text>
           </Pressable>
         )}
         <Text style={styles.hint}>
           {isLoggedIn
             ? 'User info set. Tap "Open Chat" to talk with support.'
-            : 'Login to set user information, then open the chat.'}
+            : "Login to set user information, then open the chat."}
         </Text>
 
         {/* Open Chat */}
         <Text style={[styles.sectionTitle, { marginTop: 24 }]}>Chat</Text>
-        <Pressable
-          style={[styles.button, styles.chatButton]}
-          onPress={() => Crisp.show()}
-        >
+        <Pressable style={[styles.button, styles.chatButton]} onPress={() => show()}>
           <Text style={styles.buttonText}>Open Chat</Text>
         </Pressable>
 
         {/* Events */}
-        <Text style={[styles.sectionTitle, { marginTop: 24 }]}>
-          Events Callbacks
-        </Text>
+        <Text style={[styles.sectionTitle, { marginTop: 24 }]}>Events Callbacks</Text>
         <View style={styles.statusContainer}>
           <View style={styles.statusRow}>
             <Text style={styles.statusLabel}>Chat Status:</Text>
             <View
               style={[
                 styles.statusBadge,
-                chatStatus === 'open' ? styles.statusOpen : styles.statusClosed,
+                chatStatus === "open" ? styles.statusOpen : styles.statusClosed,
               ]}
             >
-              <Text style={styles.statusBadgeText}>
-                {chatStatus.toUpperCase()}
-              </Text>
+              <Text style={styles.statusBadgeText}>{chatStatus.toUpperCase()}</Text>
             </View>
           </View>
           <View style={styles.statusRow}>
             <Text style={styles.statusLabel}>Session ID:</Text>
-            <Text style={styles.statusValue}>{sessionId ?? 'Not loaded'}</Text>
+            <Text style={styles.statusValue}>{sessionId ?? "Not loaded"}</Text>
           </View>
         </View>
 
         {/* Messages */}
-        <Text style={[styles.sectionTitle, { marginTop: 24 }]}>
-          Show Message Test
-        </Text>
+        <Text style={[styles.sectionTitle, { marginTop: 24 }]}>Show Message Test</Text>
         <View style={styles.messageButtons}>
           <Pressable
             style={[styles.button, styles.messageButton]}
             onPress={() => {
-              Crisp.showMessage({ type: 'text', text: 'Hello from Crisp!' });
+              showMessage({ type: "text", text: "Hello from Crisp!" });
             }}
           >
             <Text style={styles.buttonText}>Text Message</Text>
@@ -213,14 +198,14 @@ function HomeScreen() {
           <Pressable
             style={[styles.button, styles.messageButton]}
             onPress={() => {
-              Crisp.showMessage({
-                type: 'picker',
-                id: 'rating',
-                text: 'How would you rate our service?',
+              showMessage({
+                type: "picker",
+                id: "rating",
+                text: "How would you rate our service?",
                 choices: [
-                  { value: 'great', label: 'Great!', selected: false },
-                  { value: 'ok', label: "It's okay", selected: false },
-                  { value: 'poor', label: 'Could be better', selected: false },
+                  { value: "great", label: "Great!", selected: false },
+                  { value: "ok", label: "It's okay", selected: false },
+                  { value: "poor", label: "Could be better", selected: false },
                 ],
               });
             }}
@@ -230,9 +215,9 @@ function HomeScreen() {
           <Pressable
             style={[styles.button, styles.messageButton]}
             onPress={() => {
-              Crisp.showMessage({
-                type: 'field',
-                id: 'email',
+              showMessage({
+                type: "field",
+                id: "email",
                 text: "What's your email?",
                 explain: "We'll send you a confirmation",
                 required: true,
@@ -242,14 +227,10 @@ function HomeScreen() {
             <Text style={styles.buttonText}>Field Message</Text>
           </Pressable>
         </View>
-        <Text style={styles.hint}>
-          Tap a button then open the chat to see the message.
-        </Text>
+        <Text style={styles.hint}>Tap a button then open the chat to see the message.</Text>
 
         {/* Push Notifications */}
-        <Text style={[styles.sectionTitle, { marginTop: 24 }]}>
-          Push Notifications
-        </Text>
+        <Text style={[styles.sectionTitle, { marginTop: 24 }]}>Push Notifications</Text>
         <View style={styles.statusContainer}>
           {lastNotification ? (
             <>
@@ -263,32 +244,28 @@ function HomeScreen() {
               </View>
             </>
           ) : (
-            <Text style={styles.statusLabel}>
-              No Crisp notification received yet
-            </Text>
+            <Text style={styles.statusLabel}>No Crisp notification received yet</Text>
           )}
         </View>
         <Pressable
           style={[styles.button, styles.messageButton, { marginTop: 12 }]}
           onPress={() => {
-            Crisp.setShouldPromptForNotificationPermission(false);
-            console.log('[Crisp] Disabled auto notification prompt');
+            setShouldPromptForNotificationPermission(false);
+            console.log("[Crisp] Disabled auto notification prompt");
           }}
         >
           <Text style={styles.buttonText}>Disable Auto Prompt</Text>
         </Pressable>
 
         {/* Logger */}
-        <Text style={[styles.sectionTitle, { marginTop: 24 }]}>
-          Logger Test
-        </Text>
+        <Text style={[styles.sectionTitle, { marginTop: 24 }]}>Logger Test</Text>
         <View style={styles.logLevelButtons}>
           {(
             [
-              { level: CrispLogLevel.DEBUG, label: 'DEBUG' },
-              { level: CrispLogLevel.INFO, label: 'INFO' },
-              { level: CrispLogLevel.WARN, label: 'WARN' },
-              { level: CrispLogLevel.ERROR, label: 'ERROR' },
+              { level: CrispLogLevel.DEBUG, label: "DEBUG" },
+              { level: CrispLogLevel.INFO, label: "INFO" },
+              { level: CrispLogLevel.WARN, label: "WARN" },
+              { level: CrispLogLevel.ERROR, label: "ERROR" },
             ] as const
           ).map(({ level, label }) => (
             <Pressable
@@ -310,9 +287,7 @@ function HomeScreen() {
             </Pressable>
           ))}
         </View>
-        <Text style={styles.hint}>
-          Current level: {getLogLevelName(currentLogLevel)}
-        </Text>
+        <Text style={styles.hint}>Current level: {getLogLevelName(currentLogLevel)}</Text>
 
         {logs.length > 0 && (
           <View style={styles.logsContainer}>
@@ -323,7 +298,7 @@ function HomeScreen() {
               </Pressable>
             </View>
             <ScrollView style={styles.logsList}>
-              {logs.map(log => (
+              {logs.map((log) => (
                 <View key={log.id} style={styles.logEntry}>
                   <Text
                     style={[
@@ -360,7 +335,7 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f8f9fa',
+    backgroundColor: "#f8f9fa",
     padding: 20,
   },
   header: {
@@ -369,17 +344,17 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 28,
-    fontWeight: 'bold',
-    color: '#1a1a1a',
+    fontWeight: "bold",
+    color: "#1a1a1a",
   },
   subtitle: {
     fontSize: 16,
-    color: '#666',
+    color: "#666",
     marginTop: 4,
   },
   version: {
     fontSize: 12,
-    color: '#999',
+    color: "#999",
     marginTop: 2,
   },
   content: {
@@ -390,55 +365,55 @@ const styles = StyleSheet.create({
   },
   sectionTitle: {
     fontSize: 13,
-    fontWeight: '600',
-    color: '#999',
-    textTransform: 'uppercase',
+    fontWeight: "600",
+    color: "#999",
+    textTransform: "uppercase",
     letterSpacing: 0.5,
     marginBottom: 16,
   },
   button: {
-    backgroundColor: '#0066FF',
+    backgroundColor: "#0066FF",
     paddingVertical: 16,
     paddingHorizontal: 24,
     borderRadius: 12,
   },
   chatButton: {
-    backgroundColor: '#28a745',
+    backgroundColor: "#28a745",
   },
   logoutButton: {
-    backgroundColor: '#dc3545',
+    backgroundColor: "#dc3545",
   },
   buttonText: {
-    color: '#fff',
+    color: "#fff",
     fontSize: 16,
-    fontWeight: '600',
-    textAlign: 'center',
+    fontWeight: "600",
+    textAlign: "center",
   },
   hint: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
     marginTop: 16,
     lineHeight: 20,
   },
   statusContainer: {
-    backgroundColor: '#fff',
+    backgroundColor: "#fff",
     borderRadius: 12,
     padding: 16,
     gap: 12,
   },
   statusRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
   statusLabel: {
     fontSize: 14,
-    color: '#666',
+    color: "#666",
   },
   statusValue: {
     fontSize: 14,
-    color: '#1a1a1a',
-    fontFamily: 'monospace',
+    color: "#1a1a1a",
+    fontFamily: "monospace",
     flexShrink: 1,
   },
   statusBadge: {
@@ -447,102 +422,102 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   statusOpen: {
-    backgroundColor: '#d4edda',
+    backgroundColor: "#d4edda",
   },
   statusClosed: {
-    backgroundColor: '#f8d7da',
+    backgroundColor: "#f8d7da",
   },
   statusBadgeText: {
     fontSize: 12,
-    fontWeight: '600',
+    fontWeight: "600",
   },
   messageButtons: {
     gap: 12,
   },
   messageButton: {
-    backgroundColor: '#6c757d',
+    backgroundColor: "#6c757d",
   },
   logLevelButtons: {
-    flexDirection: 'row',
+    flexDirection: "row",
     gap: 8,
-    flexWrap: 'wrap',
+    flexWrap: "wrap",
   },
   logLevelButton: {
     paddingHorizontal: 16,
     paddingVertical: 8,
     borderRadius: 8,
-    backgroundColor: '#e9ecef',
+    backgroundColor: "#e9ecef",
     borderWidth: 2,
-    borderColor: 'transparent',
+    borderColor: "transparent",
   },
   logLevelButtonActive: {
-    backgroundColor: '#0066FF',
-    borderColor: '#0066FF',
+    backgroundColor: "#0066FF",
+    borderColor: "#0066FF",
   },
   logLevelButtonText: {
     fontSize: 12,
-    fontWeight: '600',
-    color: '#495057',
+    fontWeight: "600",
+    color: "#495057",
   },
   logLevelButtonTextActive: {
-    color: '#fff',
+    color: "#fff",
   },
   logsContainer: {
     marginTop: 16,
-    backgroundColor: '#1a1a1a',
+    backgroundColor: "#1a1a1a",
     borderRadius: 12,
     padding: 12,
     maxHeight: 200,
   },
   logsHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
     marginBottom: 8,
   },
   logsTitle: {
     fontSize: 12,
-    fontWeight: '600',
-    color: '#888',
+    fontWeight: "600",
+    color: "#888",
   },
   clearButton: {
     fontSize: 12,
-    color: '#0066FF',
-    fontWeight: '600',
+    color: "#0066FF",
+    fontWeight: "600",
   },
   logsList: {
     flex: 1,
   },
   logEntry: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
+    flexDirection: "row",
+    alignItems: "flex-start",
     marginBottom: 4,
     gap: 4,
   },
   logLevel: {
     fontSize: 10,
-    fontFamily: 'monospace',
-    color: '#6c757d',
-    fontWeight: '600',
+    fontFamily: "monospace",
+    color: "#6c757d",
+    fontWeight: "600",
   },
   logLevelError: {
-    color: '#dc3545',
+    color: "#dc3545",
   },
   logLevelWarn: {
-    color: '#ffc107',
+    color: "#ffc107",
   },
   logLevelInfo: {
-    color: '#17a2b8',
+    color: "#17a2b8",
   },
   logTag: {
     fontSize: 10,
-    fontFamily: 'monospace',
-    color: '#888',
+    fontFamily: "monospace",
+    color: "#888",
   },
   logMessage: {
     fontSize: 10,
-    fontFamily: 'monospace',
-    color: '#ccc',
+    fontFamily: "monospace",
+    color: "#ccc",
     flex: 1,
   },
 });

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -1,8 +1,19 @@
-import Crisp, {
+import {
   type CrispLogEntry,
   CrispLogLevel,
+  configure,
   getSDKVersion,
   type PushNotificationPayload,
+  resetSession,
+  setLogLevel,
+  setShouldPromptForNotificationPermission,
+  setTokenId,
+  setUserCompany,
+  setUserEmail,
+  setUserNickname,
+  setUserPhone,
+  show,
+  showMessage,
   useCrispEvents,
 } from "expo-crisp-sdk";
 import { useEffect, useState } from "react";
@@ -90,15 +101,15 @@ export default function HomeScreen() {
 
   useEffect(() => {
     // 2. Configure Crisp with your Website ID (required before any other call)
-    Crisp.configure(WEBSITE_ID);
+    configure(WEBSITE_ID);
 
     // 3. Enable debug logging to receive logs via onLogReceived
-    Crisp.setLogLevel(CrispLogLevel.DEBUG);
+    setLogLevel(CrispLogLevel.DEBUG);
   }, []);
 
   // Change log level dynamically
   const handleSetLogLevel = (level: CrispLogLevel) => {
-    Crisp.setLogLevel(level);
+    setLogLevel(level);
     setCurrentLogLevel(level);
     setLogs([]); // Clear logs when changing level
   };
@@ -106,15 +117,15 @@ export default function HomeScreen() {
   // 3. Optional: Set user information when they log in
   const handleLogin = () => {
     // Use a unique token to persist sessions across devices
-    Crisp.setTokenId("e041988c-fe41-4901-88b5-4953e1513b9e");
+    setTokenId("e041988c-fe41-4901-88b5-4953e1513b9e");
 
     // Set user details
-    Crisp.setUserEmail("armand_petit@outlook.fr");
-    Crisp.setUserNickname("Armand PETIT");
-    Crisp.setUserPhone("+33783949275");
+    setUserEmail("armand_petit@outlook.fr");
+    setUserNickname("Armand PETIT");
+    setUserPhone("+33783949275");
 
     // Add company information with full details
-    Crisp.setUserCompany({
+    setUserCompany({
       name: "Crisp",
       url: "https://crisp.chat/",
       companyDescription: "Customer Messaging Platform",
@@ -133,8 +144,8 @@ export default function HomeScreen() {
 
   // 4. Clear session when user logs out
   const handleLogout = () => {
-    Crisp.setTokenId(null);
-    Crisp.resetSession();
+    setTokenId(null);
+    resetSession();
     setIsLoggedIn(false);
   };
 
@@ -195,7 +206,7 @@ export default function HomeScreen() {
           <Pressable
             style={[styles.button, styles.messageButton]}
             onPress={() => {
-              Crisp.showMessage({
+              showMessage({
                 type: "text",
                 text: "Hello from Crisp Team !",
               });
@@ -208,7 +219,7 @@ export default function HomeScreen() {
           <Pressable
             style={[styles.button, styles.messageButton]}
             onPress={() => {
-              Crisp.showMessage({
+              showMessage({
                 type: "picker",
                 id: "rating",
                 text: "How would you rate our service?",
@@ -231,7 +242,7 @@ export default function HomeScreen() {
           <Pressable
             style={[styles.button, styles.messageButton]}
             onPress={() => {
-              Crisp.showMessage({
+              showMessage({
                 type: "field",
                 id: "email",
                 text: "What's your email address?",
@@ -273,7 +284,7 @@ export default function HomeScreen() {
           <Pressable
             style={[styles.button, styles.messageButton]}
             onPress={() => {
-              Crisp.setShouldPromptForNotificationPermission(false);
+              setShouldPromptForNotificationPermission(false);
               console.log("[Crisp] Disabled auto notification prompt");
             }}
           >
@@ -407,7 +418,7 @@ export default function HomeScreen() {
       </ScrollView>
 
       {/* 5. Floating chat button - tap to open Crisp chat */}
-      <CrispButton onPress={() => Crisp.show()} />
+      <CrispButton onPress={() => show()} />
     </SafeAreaView>
   );
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,15 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
   roots: ["<rootDir>/src"],
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
   transform: {
-    "^.+\\.tsx?$": "ts-jest",
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          resolveJsonModule: true,
+        },
+      },
+    ],
   },
 };

--- a/src/ExpoCrispSdk.types.ts
+++ b/src/ExpoCrispSdk.types.ts
@@ -17,10 +17,10 @@
  * import { CrispSessionEventColors } from "expo-crisp-sdk";
  *
  * // Use GREEN for successful actions
- * ExpoCrispSdk.pushSessionEvent("Purchase completed", CrispSessionEventColors.GREEN);
+ * pushSessionEvent("Purchase completed", CrispSessionEventColors.GREEN);
  *
  * // Use RED for errors or issues
- * ExpoCrispSdk.pushSessionEvent("Payment failed", CrispSessionEventColors.RED);
+ * pushSessionEvent("Payment failed", CrispSessionEventColors.RED);
  * ```
  */
 export enum CrispSessionEventColors {
@@ -52,13 +52,13 @@ export enum CrispSessionEventColors {
  *
  * @example
  * ```typescript
- * import ExpoCrispSdk, { CrispLogLevel } from "expo-crisp-sdk";
+ * import { setLogLevel, CrispLogLevel } from "expo-crisp-sdk";
  *
  * // Set to DEBUG to see more detailed logs
- * ExpoCrispSdk.setLogLevel(CrispLogLevel.DEBUG);
+ * setLogLevel(CrispLogLevel.DEBUG);
  *
  * // Set to ERROR to only see errors
- * ExpoCrispSdk.setLogLevel(CrispLogLevel.ERROR);
+ * setLogLevel(CrispLogLevel.ERROR);
  * ```
  */
 export enum CrispLogLevel {
@@ -132,9 +132,9 @@ export interface Geolocation {
  *
  * @example
  * ```typescript
- * import ExpoCrispSdk from "expo-crisp-sdk";
+ * import { setUserCompany } from "expo-crisp-sdk";
  *
- * ExpoCrispSdk.setUserCompany({
+ * setUserCompany({
  *   name: "Acme Corporation",
  *   url: "https://acme.com",
  *   companyDescription: "Leading provider of innovative solutions",
@@ -188,7 +188,7 @@ export interface Company {
  *
  * @example
  * ```typescript
- * import ExpoCrispSdk, { CrispSessionEventColors, SessionEvent } from "expo-crisp-sdk";
+ * import { pushSessionEvents, CrispSessionEventColors, type SessionEvent } from "expo-crisp-sdk";
  *
  * const events: SessionEvent[] = [
  *   { name: "Viewed pricing page", color: CrispSessionEventColors.BLUE },
@@ -196,7 +196,7 @@ export interface Company {
  *   { name: "Upgraded to Pro", color: CrispSessionEventColors.PURPLE }
  * ];
  *
- * ExpoCrispSdk.pushSessionEvents(events);
+ * pushSessionEvents(events);
  * ```
  */
 export interface SessionEvent {
@@ -407,6 +407,36 @@ export interface PushNotificationPayload {
 }
 
 // ============================================================================
+// Helpdesk Types
+// ============================================================================
+
+/**
+ * Options for opening a helpdesk article.
+ *
+ * @example
+ * ```typescript
+ * import { openHelpdeskArticle } from "expo-crisp-sdk";
+ *
+ * openHelpdeskArticle({
+ *   id: "article-slug",
+ *   locale: "en",
+ *   title: "Getting Started",
+ *   category: "Guides",
+ * });
+ * ```
+ */
+export interface HelpdeskArticleOptions {
+  /** Article slug or identifier */
+  id: string;
+  /** Article locale (e.g., "en", "fr") */
+  locale: string;
+  /** Optional article title for display */
+  title?: string | null;
+  /** Optional category name for display */
+  category?: string | null;
+}
+
+// ============================================================================
 // Message Content Types (for showMessage)
 // ============================================================================
 
@@ -415,7 +445,7 @@ export interface PushNotificationPayload {
  *
  * @example
  * ```typescript
- * Crisp.showMessage({ type: "text", text: "Hello! How can I help you?" });
+ * showMessage({ type: "text", text: "Hello! How can I help you?" });
  * ```
  */
 export interface TextMessageContent {
@@ -429,7 +459,7 @@ export interface TextMessageContent {
  *
  * @example
  * ```typescript
- * Crisp.showMessage({
+ * showMessage({
  *   type: "file",
  *   url: "https://example.com/document.pdf",
  *   name: "Document.pdf",
@@ -452,7 +482,7 @@ export interface FileMessageContent {
  *
  * @example
  * ```typescript
- * Crisp.showMessage({
+ * showMessage({
  *   type: "animation",
  *   url: "https://example.com/animation.gif",
  *   mimeType: "image/gif"
@@ -472,7 +502,7 @@ export interface AnimationMessageContent {
  *
  * @example
  * ```typescript
- * Crisp.showMessage({
+ * showMessage({
  *   type: "audio",
  *   url: "https://example.com/audio.mp3",
  *   mimeType: "audio/mpeg",
@@ -507,7 +537,7 @@ export interface PickerChoice {
  *
  * @example
  * ```typescript
- * Crisp.showMessage({
+ * showMessage({
  *   type: "picker",
  *   id: "satisfaction",
  *   text: "How satisfied are you?",
@@ -534,7 +564,7 @@ export interface PickerMessageContent {
  *
  * @example
  * ```typescript
- * Crisp.showMessage({
+ * showMessage({
  *   type: "field",
  *   id: "email",
  *   text: "What's your email?",
@@ -574,7 +604,7 @@ export interface CarouselTarget {
  *
  * @example
  * ```typescript
- * Crisp.showMessage({
+ * showMessage({
  *   type: "carousel",
  *   text: "Check out our products",
  *   targets: [
@@ -599,10 +629,10 @@ export interface CarouselMessageContent {
  * @example
  * ```typescript
  * // Simple text message
- * Crisp.showMessage({ type: "text", text: "Hello!" });
+ * showMessage({ type: "text", text: "Hello!" });
  *
  * // File attachment
- * Crisp.showMessage({
+ * showMessage({
  *   type: "file",
  *   url: "https://example.com/doc.pdf",
  *   name: "doc.pdf",
@@ -610,7 +640,7 @@ export interface CarouselMessageContent {
  * });
  *
  * // Picker for user choice
- * Crisp.showMessage({
+ * showMessage({
  *   type: "picker",
  *   id: "rating",
  *   text: "Rate us",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,272 @@
+const mockModule = {
+  configure: jest.fn(),
+  setTokenId: jest.fn(),
+  setLogLevel: jest.fn(),
+  setUserEmail: jest.fn(),
+  setUserNickname: jest.fn(),
+  setUserPhone: jest.fn(),
+  setUserCompany: jest.fn(),
+  setUserAvatar: jest.fn(),
+  setSessionString: jest.fn(),
+  setSessionBool: jest.fn(),
+  setSessionInt: jest.fn(),
+  setSessionSegment: jest.fn(),
+  setSessionSegments: jest.fn(),
+  getSessionIdentifier: jest.fn(),
+  pushSessionEvent: jest.fn(),
+  pushSessionEvents: jest.fn(),
+  resetSession: jest.fn(),
+  show: jest.fn(),
+  searchHelpdesk: jest.fn(),
+  openHelpdeskArticle: jest.fn(),
+  runBotScenario: jest.fn(),
+  registerPushToken: jest.fn(),
+  isCrispPushNotification: jest.fn(),
+  setShouldPromptForNotificationPermission: jest.fn(),
+  showMessage: jest.fn(),
+};
+
+jest.mock("../ExpoCrispSdkModule", () => ({
+  __esModule: true,
+  default: mockModule,
+}));
+
+import {
+  configure,
+  getSessionIdentifier,
+  isCrispPushNotification,
+  openHelpdeskArticle,
+  pushSessionEvent,
+  pushSessionEvents,
+  registerPushToken,
+  resetSession,
+  runBotScenario,
+  searchHelpdesk,
+  setLogLevel,
+  setSessionBool,
+  setSessionInt,
+  setSessionSegment,
+  setSessionSegments,
+  setSessionString,
+  setShouldPromptForNotificationPermission,
+  setTokenId,
+  setUserAvatar,
+  setUserCompany,
+  setUserEmail,
+  setUserNickname,
+  setUserPhone,
+  show,
+  showMessage,
+} from "../index";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("wrapper functions", () => {
+  // ---- Configuration ----
+
+  it("configure delegates to native module", () => {
+    configure("website-123");
+    expect(mockModule.configure).toHaveBeenCalledWith("website-123");
+  });
+
+  it("setTokenId delegates to native module", () => {
+    setTokenId("token-abc");
+    expect(mockModule.setTokenId).toHaveBeenCalledWith("token-abc");
+  });
+
+  it("setTokenId accepts null", () => {
+    setTokenId(null);
+    expect(mockModule.setTokenId).toHaveBeenCalledWith(null);
+  });
+
+  it("setLogLevel delegates to native module", () => {
+    setLogLevel(2);
+    expect(mockModule.setLogLevel).toHaveBeenCalledWith(2);
+  });
+
+  // ---- User Information ----
+
+  it("setUserEmail delegates with email only", () => {
+    setUserEmail("test@example.com");
+    expect(mockModule.setUserEmail).toHaveBeenCalledWith("test@example.com", undefined);
+  });
+
+  it("setUserEmail delegates with email and signature", () => {
+    setUserEmail("test@example.com", "sig-123");
+    expect(mockModule.setUserEmail).toHaveBeenCalledWith("test@example.com", "sig-123");
+  });
+
+  it("setUserNickname delegates to native module", () => {
+    setUserNickname("John");
+    expect(mockModule.setUserNickname).toHaveBeenCalledWith("John");
+  });
+
+  it("setUserPhone delegates to native module", () => {
+    setUserPhone("+33600000000");
+    expect(mockModule.setUserPhone).toHaveBeenCalledWith("+33600000000");
+  });
+
+  it("setUserCompany delegates to native module", () => {
+    const company = { name: "Acme", url: "https://acme.com" };
+    setUserCompany(company);
+    expect(mockModule.setUserCompany).toHaveBeenCalledWith(company);
+  });
+
+  it("setUserAvatar delegates to native module", () => {
+    setUserAvatar("https://example.com/avatar.png");
+    expect(mockModule.setUserAvatar).toHaveBeenCalledWith("https://example.com/avatar.png");
+  });
+
+  // ---- Session Data ----
+
+  it("setSessionString delegates to native module", () => {
+    setSessionString("key", "value");
+    expect(mockModule.setSessionString).toHaveBeenCalledWith("key", "value");
+  });
+
+  it("setSessionBool delegates to native module", () => {
+    setSessionBool("premium", true);
+    expect(mockModule.setSessionBool).toHaveBeenCalledWith("premium", true);
+  });
+
+  it("setSessionInt delegates to native module", () => {
+    setSessionInt("visits", 42);
+    expect(mockModule.setSessionInt).toHaveBeenCalledWith("visits", 42);
+  });
+
+  it("setSessionSegment delegates to native module", () => {
+    setSessionSegment("vip");
+    expect(mockModule.setSessionSegment).toHaveBeenCalledWith("vip");
+  });
+
+  it("setSessionSegments delegates to native module", () => {
+    setSessionSegments(["vip", "beta"], true);
+    expect(mockModule.setSessionSegments).toHaveBeenCalledWith(["vip", "beta"], true);
+  });
+
+  it("setSessionSegments defaults overwrite to false when omitted", () => {
+    setSessionSegments(["vip"]);
+    expect(mockModule.setSessionSegments).toHaveBeenCalledWith(["vip"], false);
+  });
+
+  it("getSessionIdentifier delegates to native module", async () => {
+    mockModule.getSessionIdentifier.mockResolvedValue("session-xyz");
+    const result = await getSessionIdentifier();
+    expect(result).toBe("session-xyz");
+    expect(mockModule.getSessionIdentifier).toHaveBeenCalled();
+  });
+
+  it("getSessionIdentifier returns null when no session", async () => {
+    mockModule.getSessionIdentifier.mockResolvedValue(null);
+    const result = await getSessionIdentifier();
+    expect(result).toBeNull();
+  });
+
+  // ---- Events ----
+
+  it("pushSessionEvent delegates to native module", () => {
+    pushSessionEvent("Checkout", 3);
+    expect(mockModule.pushSessionEvent).toHaveBeenCalledWith("Checkout", 3);
+  });
+
+  it("pushSessionEvents delegates to native module", () => {
+    const events = [
+      { name: "A", color: 0 },
+      { name: "B", color: 1 },
+    ];
+    pushSessionEvents(events);
+    expect(mockModule.pushSessionEvents).toHaveBeenCalledWith(events);
+  });
+
+  // ---- Session Management ----
+
+  it("resetSession delegates to native module", () => {
+    resetSession();
+    expect(mockModule.resetSession).toHaveBeenCalled();
+  });
+
+  // ---- UI ----
+
+  it("show delegates to native module", () => {
+    show();
+    expect(mockModule.show).toHaveBeenCalled();
+  });
+
+  it("searchHelpdesk delegates to native module", () => {
+    searchHelpdesk();
+    expect(mockModule.searchHelpdesk).toHaveBeenCalled();
+  });
+
+  it("openHelpdeskArticle converts options object to positional args", () => {
+    openHelpdeskArticle({
+      id: "getting-started",
+      locale: "en",
+      title: "Getting Started",
+      category: "Guides",
+    });
+    expect(mockModule.openHelpdeskArticle).toHaveBeenCalledWith(
+      "getting-started",
+      "en",
+      "Getting Started",
+      "Guides",
+    );
+  });
+
+  it("openHelpdeskArticle works with only required fields", () => {
+    openHelpdeskArticle({ id: "article-1", locale: "fr" });
+    expect(mockModule.openHelpdeskArticle).toHaveBeenCalledWith(
+      "article-1",
+      "fr",
+      undefined,
+      undefined,
+    );
+  });
+
+  it("runBotScenario delegates to native module", () => {
+    runBotScenario("scenario-123");
+    expect(mockModule.runBotScenario).toHaveBeenCalledWith("scenario-123");
+  });
+
+  // ---- Push Notifications ----
+
+  it("registerPushToken delegates to native module", () => {
+    registerPushToken("fcm-token-xyz");
+    expect(mockModule.registerPushToken).toHaveBeenCalledWith("fcm-token-xyz");
+  });
+
+  it("isCrispPushNotification delegates and returns result", () => {
+    mockModule.isCrispPushNotification.mockReturnValue(true);
+    const result = isCrispPushNotification({ from: "crisp" });
+    expect(result).toBe(true);
+    expect(mockModule.isCrispPushNotification).toHaveBeenCalledWith({ from: "crisp" });
+  });
+
+  it("isCrispPushNotification returns false for non-crisp", () => {
+    mockModule.isCrispPushNotification.mockReturnValue(false);
+    const result = isCrispPushNotification({ from: "other" });
+    expect(result).toBe(false);
+  });
+
+  it("setShouldPromptForNotificationPermission delegates to native module", () => {
+    setShouldPromptForNotificationPermission(false);
+    expect(mockModule.setShouldPromptForNotificationPermission).toHaveBeenCalledWith(false);
+  });
+
+  // ---- Messages ----
+
+  it("showMessage delegates to native module", () => {
+    const content = { type: "text" as const, text: "Hello!" };
+    showMessage(content);
+    expect(mockModule.showMessage).toHaveBeenCalledWith(content);
+  });
+});
+
+describe("module encapsulation", () => {
+  it("does not export native module as default", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const indexExports = require("../index");
+    expect(indexExports.default).toBeUndefined();
+  });
+});

--- a/src/__tests__/useCrispEvents.test.ts
+++ b/src/__tests__/useCrispEvents.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 
 // Mock the native module before importing the hook
 const mockRemove = jest.fn();
@@ -11,8 +11,8 @@ jest.mock("../ExpoCrispSdkModule", () => ({
   },
 }));
 
+import type { CrispLogEntry, CrispMessage, PushNotificationPayload } from "../ExpoCrispSdk.types";
 import { useCrispEvents } from "../useCrispEvents";
-import type { CrispMessage, CrispLogEntry, PushNotificationPayload } from "../ExpoCrispSdk.types";
 
 beforeEach(() => {
   mockAddListener.mockClear();
@@ -31,7 +31,10 @@ describe("useCrispEvents", () => {
     expect(mockAddListener).toHaveBeenCalledWith("onMessageSent", expect.any(Function));
     expect(mockAddListener).toHaveBeenCalledWith("onMessageReceived", expect.any(Function));
     expect(mockAddListener).toHaveBeenCalledWith("onLogReceived", expect.any(Function));
-    expect(mockAddListener).toHaveBeenCalledWith("onPushNotificationReceived", expect.any(Function));
+    expect(mockAddListener).toHaveBeenCalledWith(
+      "onPushNotificationReceived",
+      expect.any(Function),
+    );
   });
 
   it("removes all subscriptions on unmount", () => {
@@ -183,7 +186,9 @@ describe("useCrispEvents", () => {
 
 /** Helper to extract the listener handler for a specific event */
 function getListenerHandler(eventName: string): (...args: unknown[]) => void {
-  const calls = mockAddListener.mock.calls as unknown as Array<[string, (...args: unknown[]) => void]>;
+  const calls = mockAddListener.mock.calls as unknown as Array<
+    [string, (...args: unknown[]) => void]
+  >;
   const call = calls.find(([name]) => name === eventName);
   if (!call) throw new Error(`No listener registered for ${eventName}`);
   return call[1];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,287 @@
+import type {
+  Company,
+  CrispLogLevel,
+  CrispSessionEventColors,
+  HelpdeskArticleOptions,
+  MessageContent,
+  SessionEvent,
+} from "./ExpoCrispSdk.types";
+import ExpoCrispSdkModule from "./ExpoCrispSdkModule";
+
+// Re-export types, hook, and utilities
 export * from "./ExpoCrispSdk.types";
-export { default } from "./ExpoCrispSdkModule";
 export type { CrispEventCallbacks } from "./useCrispEvents";
 export { useCrispEvents } from "./useCrispEvents";
 export { getSDKVersion } from "./version";
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/**
+ * Initialize the Crisp SDK with your website ID.
+ * Must be called once at app startup before using any other methods.
+ *
+ * @param websiteId - Your Website ID from the Crisp Dashboard
+ */
+export function configure(websiteId: string): void {
+  ExpoCrispSdkModule.configure(websiteId);
+}
+
+/**
+ * Set a token for session persistence across app reinstalls and devices.
+ *
+ * @param tokenId - Unique identifier (e.g., user ID), or `null` to clear
+ */
+export function setTokenId(tokenId: string | null): void {
+  ExpoCrispSdkModule.setTokenId(tokenId);
+}
+
+/**
+ * Set the minimum log level for SDK logging.
+ *
+ * @param level - Minimum log level to emit
+ */
+export function setLogLevel(level: CrispLogLevel): void {
+  ExpoCrispSdkModule.setLogLevel(level);
+}
+
+// ============================================================================
+// User Information
+// ============================================================================
+
+/**
+ * Set the user's email address for identification in the chat.
+ *
+ * @param email - User's email address
+ * @param signature - Optional HMAC-SHA256 signature for email verification
+ */
+export function setUserEmail(email: string, signature?: string | null): void {
+  ExpoCrispSdkModule.setUserEmail(email, signature);
+}
+
+/**
+ * Set the user's display name shown in the chat.
+ *
+ * @param name - User's nickname or display name
+ */
+export function setUserNickname(name: string): void {
+  ExpoCrispSdkModule.setUserNickname(name);
+}
+
+/**
+ * Set the user's phone number.
+ *
+ * @param phone - Phone number (E.164 format recommended)
+ */
+export function setUserPhone(phone: string): void {
+  ExpoCrispSdkModule.setUserPhone(phone);
+}
+
+/**
+ * Set the user's company information.
+ *
+ * @param company - Company details including name, URL, employment, and location
+ */
+export function setUserCompany(company: Company): void {
+  ExpoCrispSdkModule.setUserCompany(company);
+}
+
+/**
+ * Set the user's avatar image.
+ *
+ * @param url - URL to the user's avatar image
+ */
+export function setUserAvatar(url: string): void {
+  ExpoCrispSdkModule.setUserAvatar(url);
+}
+
+// ============================================================================
+// Session Data
+// ============================================================================
+
+/**
+ * Store a custom string value in the session data.
+ *
+ * @param key - Data key
+ * @param value - String value to store
+ */
+export function setSessionString(key: string, value: string): void {
+  ExpoCrispSdkModule.setSessionString(key, value);
+}
+
+/**
+ * Store a custom boolean value in the session data.
+ *
+ * @param key - Data key
+ * @param value - Boolean value to store
+ */
+export function setSessionBool(key: string, value: boolean): void {
+  ExpoCrispSdkModule.setSessionBool(key, value);
+}
+
+/**
+ * Store a custom integer value in the session data.
+ *
+ * @param key - Data key
+ * @param value - Integer value to store
+ */
+export function setSessionInt(key: string, value: number): void {
+  ExpoCrispSdkModule.setSessionInt(key, value);
+}
+
+/**
+ * Set a single segment to categorize the user.
+ *
+ * @param segment - Segment name (e.g., "premium", "trial")
+ */
+export function setSessionSegment(segment: string): void {
+  ExpoCrispSdkModule.setSessionSegment(segment);
+}
+
+/**
+ * Set multiple segments to categorize the user.
+ *
+ * @param segments - Array of segment names
+ * @param overwrite - If true, replaces existing segments; if false, appends
+ */
+export function setSessionSegments(segments: string[], overwrite?: boolean): void {
+  ExpoCrispSdkModule.setSessionSegments(segments, overwrite ?? false);
+}
+
+/**
+ * Get the current session identifier.
+ *
+ * @returns Promise resolving to the session ID, or `null` if no session is active yet.
+ *
+ * @remarks
+ * Returns `null` in these cases:
+ * - Session hasn't loaded yet (wait for `onSessionLoaded` event first)
+ * - `configure()` was not called
+ * - Native SDK hasn't established a session
+ */
+export function getSessionIdentifier(): Promise<string | null> {
+  return ExpoCrispSdkModule.getSessionIdentifier();
+}
+
+// ============================================================================
+// Events
+// ============================================================================
+
+/**
+ * Track a single event in the user's chat timeline.
+ *
+ * @param name - Event name (e.g., "Purchase completed")
+ * @param color - Event color for visual categorization
+ */
+export function pushSessionEvent(name: string, color: CrispSessionEventColors): void {
+  ExpoCrispSdkModule.pushSessionEvent(name, color);
+}
+
+/**
+ * Track multiple events in the user's chat timeline.
+ *
+ * @param events - Array of events with name and color
+ */
+export function pushSessionEvents(events: SessionEvent[]): void {
+  ExpoCrispSdkModule.pushSessionEvents(events);
+}
+
+// ============================================================================
+// Session Management
+// ============================================================================
+
+/**
+ * Reset the current chat session.
+ * Clears all session data and starts a fresh conversation.
+ */
+export function resetSession(): void {
+  ExpoCrispSdkModule.resetSession();
+}
+
+// ============================================================================
+// UI
+// ============================================================================
+
+/**
+ * Open the Crisp chat widget.
+ */
+export function show(): void {
+  ExpoCrispSdkModule.show();
+}
+
+/**
+ * Open the helpdesk search interface.
+ */
+export function searchHelpdesk(): void {
+  ExpoCrispSdkModule.searchHelpdesk();
+}
+
+/**
+ * Open a specific helpdesk article.
+ *
+ * @param options - Article options including id, locale, and optional title/category
+ */
+export function openHelpdeskArticle(options: HelpdeskArticleOptions): void {
+  ExpoCrispSdkModule.openHelpdeskArticle(
+    options.id,
+    options.locale,
+    options.title,
+    options.category,
+  );
+}
+
+/**
+ * Trigger an automated bot scenario.
+ *
+ * @param scenarioId - The scenario identifier from the Crisp dashboard
+ */
+export function runBotScenario(scenarioId: string): void {
+  ExpoCrispSdkModule.runBotScenario(scenarioId);
+}
+
+// ============================================================================
+// Push Notifications (Coexistence Mode)
+// ============================================================================
+
+/**
+ * Register a push token (FCM or APNs) with Crisp.
+ *
+ * @param token - The push token string
+ */
+export function registerPushToken(token: string): void {
+  ExpoCrispSdkModule.registerPushToken(token);
+}
+
+/**
+ * Check if a notification payload originates from Crisp.
+ *
+ * @param data - The notification data payload
+ * @returns `true` if the notification is from Crisp
+ */
+export function isCrispPushNotification(data: Record<string, string>): boolean {
+  return ExpoCrispSdkModule.isCrispPushNotification(data);
+}
+
+/**
+ * Control whether the Crisp SDK should automatically prompt for notification permissions.
+ * On Android, this is a no-op.
+ *
+ * @param enabled - `true` to allow auto-prompting, `false` to disable
+ */
+export function setShouldPromptForNotificationPermission(enabled: boolean): void {
+  ExpoCrispSdkModule.setShouldPromptForNotificationPermission(enabled);
+}
+
+// ============================================================================
+// Messages
+// ============================================================================
+
+/**
+ * Display a message as operator in the local chatbox.
+ *
+ * @param content - The message content to display
+ */
+export function showMessage(content: MessageContent): void {
+  ExpoCrispSdkModule.showMessage(content);
+}


### PR DESCRIPTION
## Summary

- **Replace `export { default }` with 25 named wrapper functions** following the Expo-recommended pattern (expo-clipboard, expo-settings)
- **Add `HelpdeskArticleOptions` type** for `openHelpdeskArticle` — options object replaces 4 positional parameters
- **Fix `setSessionSegments`** — default `overwrite` to `false` to prevent `undefined` crossing the native bridge to non-optional `Bool`/`Boolean`
- **Update README, JSDoc, and both example apps** to use new named imports

### Breaking Changes

| Before | After |
|--------|-------|
| `import Crisp from "expo-crisp-sdk"` | `import { configure, show } from "expo-crisp-sdk"` |
| `Crisp.configure("id")` | `configure("id")` |
| `Crisp.openHelpdeskArticle("slug", "en", "Title", "Cat")` | `openHelpdeskArticle({ id: "slug", locale: "en", title: "Title", category: "Cat" })` |

> Namespace import still works: `import * as Crisp from "expo-crisp-sdk"`

### Why wrapper functions?

1. **Tree-shaking** — bundlers can eliminate unused functions
2. **Explicit API** — named imports are self-documenting
3. **Normalization layer** — wrappers can default values before crossing the native bridge (e.g., `overwrite ?? false`)
4. **Expo convention** — matches expo-clipboard, expo-settings, expo-notifications patterns

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` — 44 tests (12 existing + 32 new wrapper tests)
- [x] `yarn format` — Biome check clean
- [x] All 25 wrapper functions tested for delegation
- [x] `openHelpdeskArticle` options-to-positional conversion verified
- [x] `setSessionSegments` overwrite default verified
- [x] Module encapsulation test (no default export)
- [x] Adversarial review by TypeScript expert + code reviewer