### PR TITLE
docs: add migration guide from legacy SDK

### DIFF
--- a/.changeset/add-migration-guide.md
+++ b/.changeset/add-migration-guide.md
@@ -1,0 +1,5 @@
+---
+"expo-crisp-sdk": patch
+---
+
+Add migration guide from `react-native-crisp-chat-sdk` to `expo-crisp-sdk` with step-by-step instructions, before/after code examples, and API change reference

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -30,7 +30,7 @@ npx expo install expo-crisp-sdk
 
 ## Step 2: Update `app.json` / `app.config.js`
 
-Replace the plugin entry:
+Replace the plugin name:
 
 **Before:**
 
@@ -65,8 +65,7 @@ Replace the plugin entry:
         {
           "websiteId": "YOUR_WEBSITE_ID",
           "notifications": {
-            "enabled": true,
-            "mode": "sdk-managed"
+            "enabled": true
           }
         }
       ]
@@ -75,178 +74,41 @@ Replace the plugin entry:
 }
 ```
 
-**What changed:**
-
-| | Before | After |
-|---|---|---|
-| Plugin name | `"react-native-crisp-chat-sdk"` | `"expo-crisp-sdk"` |
-| Notification mode | _(not available)_ | `"sdk-managed"` or `"coexistence"` |
-
-> **Tip:** If your app uses another push notification system (e.g., `expo-notifications`, Firebase, OneSignal), use `"coexistence"` mode instead. See the [Push Notifications docs](./docs/PUSH_NOTIFICATIONS.md) for details.
+> **Tip:** If your app uses another push notification system (e.g., `expo-notifications`, Firebase, OneSignal), you can now use `"mode": "coexistence"` in the notifications config. See the [Push Notifications docs](./docs/PUSH_NOTIFICATIONS.md) for details.
 
 ---
 
 ## Step 3: Update Imports
+
+Replace the package name in your imports:
 
 **Before:**
 
 ```typescript
 import CrispChat, {
   configure,
-  setTokenId,
   setUserEmail,
-  setUserNickname,
-  setUserPhone,
-  setUserAvatar,
-  setUserCompany,
-  setSessionSegment,
-  setSessionSegments,
-  setSessionString,
-  setSessionBool,
-  setSessionInt,
-  getSessionIdentifier,
-  pushSessionEvent,
-  pushSessionEvents,
-  resetSession,
   show,
-  searchHelpdesk,
-  openHelpdeskArticle,
-  runBotScenario,
-  CrispSessionEventColors,
+  // ... other imports
 } from "react-native-crisp-chat-sdk";
 ```
 
 **After:**
 
 ```typescript
-import {
+import CrispChat, {
   configure,
-  setTokenId,
   setUserEmail,
-  setUserNickname,
-  setUserPhone,
-  setUserAvatar,
-  setUserCompany,
-  setSessionSegment,
-  setSessionSegments,
-  setSessionString,
-  setSessionBool,
-  setSessionInt,
-  getSessionIdentifier,
-  pushSessionEvent,
-  pushSessionEvents,
-  resetSession,
   show,
-  searchHelpdesk,
-  openHelpdeskArticle,
-  runBotScenario,
-  CrispSessionEventColors,
+  // ... other imports
 } from "expo-crisp-sdk";
 ```
 
-**What changed:**
-
-- Package name: `"react-native-crisp-chat-sdk"` → `"expo-crisp-sdk"`
-- No more default export: `CrispChat` component is removed (see Step 4)
+All existing imports — including the `CrispChat` default export — work exactly the same.
 
 ---
 
-## Step 4: Remove the `<CrispChat />` Component
-
-The old SDK exported a `<CrispChat />` React component that called `show()` on mount. The new SDK removes this component — call `show()` directly instead.
-
-**Before:**
-
-```tsx
-import CrispChat, { configure } from "react-native-crisp-chat-sdk";
-
-export default function App() {
-  configure("YOUR_WEBSITE_ID");
-  return <CrispChat />;
-}
-```
-
-**After:**
-
-```tsx
-import { useEffect } from "react";
-import { Button, View } from "react-native";
-import { configure, show } from "expo-crisp-sdk";
-
-export default function App() {
-  useEffect(() => {
-    configure("YOUR_WEBSITE_ID");
-  }, []);
-
-  return (
-    <View>
-      <Button title="Chat with us" onPress={() => show()} />
-    </View>
-  );
-}
-```
-
----
-
-## Step 5: Update Changed Method Signatures
-
-Most methods are **identical** between the two SDKs. Only three methods have changed:
-
-### `openHelpdeskArticle` — Now takes an options object
-
-**Before:**
-
-```typescript
-openHelpdeskArticle("article-slug", "en", "Getting Started", "Guides");
-```
-
-**After:**
-
-```typescript
-openHelpdeskArticle({
-  id: "article-slug",
-  locale: "en",
-  title: "Getting Started",   // optional
-  category: "Guides",         // optional
-});
-```
-
-### `setUserEmail` — Signature parameter is now optional
-
-**Before:**
-
-```typescript
-// Without verification — had to pass null explicitly
-setUserEmail("user@example.com", null);
-
-// With verification
-setUserEmail("user@example.com", "hmac-signature");
-```
-
-**After:**
-
-```typescript
-// Without verification — just omit the second argument
-setUserEmail("user@example.com");
-
-// With verification — same as before
-setUserEmail("user@example.com", "hmac-signature");
-```
-
-### `searchHelpdesk` — No longer auto-opens the chat
-
-**Before:** `searchHelpdesk()` automatically called `show()` internally.
-
-**After:** `searchHelpdesk()` only opens the helpdesk search. If the chat is not already visible, call `show()` yourself:
-
-```typescript
-searchHelpdesk();
-show(); // Add this if you need the chat to open
-```
-
----
-
-## Step 6: Rebuild Your App
+## Step 4: Rebuild Your App
 
 After making all changes, rebuild your native projects:
 
@@ -257,33 +119,7 @@ npx expo run:ios
 npx expo run:android
 ```
 
----
-
-## Step 7: Unchanged Methods (No Action Needed)
-
-These methods work exactly the same in both SDKs — no changes required:
-
-| Method | Signature |
-|---|---|
-| `configure` | `(websiteId: string) => void` |
-| `setTokenId` | `(tokenId: string \| null) => void` |
-| `setUserNickname` | `(name: string) => void` |
-| `setUserPhone` | `(phone: string) => void` |
-| `setUserAvatar` | `(url: string) => void` |
-| `setUserCompany` | `(company: Company) => void` |
-| `setSessionSegment` | `(segment: string) => void` |
-| `setSessionSegments` | `(segments: string[], overwrite?: boolean) => void` |
-| `setSessionString` | `(key: string, value: string) => void` |
-| `setSessionBool` | `(key: string, value: boolean) => void` |
-| `setSessionInt` | `(key: string, value: number) => void` |
-| `getSessionIdentifier` | `() => Promise<string \| null>` |
-| `pushSessionEvent` | `(name: string, color: CrispSessionEventColors) => void` |
-| `pushSessionEvents` | `(events: SessionEvent[]) => void` |
-| `resetSession` | `() => void` |
-| `show` | `() => void` |
-| `runBotScenario` | `(scenarioId: string) => void` |
-
-The `Company`, `Employment`, `Geolocation`, and `CrispSessionEventColors` types are also identical.
+That's it! Your app should work exactly as before.
 
 ---
 
@@ -359,97 +195,6 @@ const isCrisp = isCrispPushNotification(notificationData);
 
 ---
 
-## Complete Before/After Example
-
-### Before (legacy SDK)
-
-```tsx
-import CrispChat, {
-  configure,
-  setTokenId,
-  setUserEmail,
-  setUserNickname,
-  resetSession,
-  CrispSessionEventColors,
-  pushSessionEvent,
-  searchHelpdesk,
-  openHelpdeskArticle,
-} from "react-native-crisp-chat-sdk";
-
-export default function App() {
-  configure("YOUR_WEBSITE_ID");
-  setTokenId("user-123");
-  setUserEmail("user@example.com", null);
-  setUserNickname("John Doe");
-  pushSessionEvent("App opened", CrispSessionEventColors.BLUE);
-
-  const openHelp = () => {
-    openHelpdeskArticle("getting-started", "en", "Getting Started", null);
-  };
-
-  const onLogout = () => {
-    setTokenId(null);
-    resetSession();
-  };
-
-  return <CrispChat />;
-}
-```
-
-### After (new SDK)
-
-```tsx
-import { useEffect } from "react";
-import { Button, View } from "react-native";
-import {
-  configure,
-  setTokenId,
-  setUserEmail,
-  setUserNickname,
-  resetSession,
-  show,
-  CrispSessionEventColors,
-  pushSessionEvent,
-  searchHelpdesk,
-  openHelpdeskArticle,
-  useCrispEvents,
-} from "expo-crisp-sdk";
-
-export default function App() {
-  useEffect(() => {
-    configure("YOUR_WEBSITE_ID");
-    setTokenId("user-123");
-    setUserEmail("user@example.com");
-    setUserNickname("John Doe");
-    pushSessionEvent("App opened", CrispSessionEventColors.BLUE);
-  }, []);
-
-  useCrispEvents({
-    onMessageReceived: (message) => {
-      console.log("New message:", message.content);
-    },
-  });
-
-  const openHelp = () => {
-    openHelpdeskArticle({ id: "getting-started", locale: "en", title: "Getting Started" });
-  };
-
-  const onLogout = () => {
-    setTokenId(null);
-    resetSession();
-  };
-
-  return (
-    <View>
-      <Button title="Chat with us" onPress={() => show()} />
-      <Button title="Help Center" onPress={openHelp} />
-    </View>
-  );
-}
-```
-
----
-
 ## Troubleshooting
 
 ### Build fails after migration
@@ -460,19 +205,11 @@ Run a clean prebuild to regenerate native projects:
 npx expo prebuild --clean
 ```
 
-### `CrispChat` is not exported
-
-The `<CrispChat />` component has been removed. Use `show()` to open the chat instead. See [Step 4](#step-4-remove-the-crispchat--component).
-
 ### Push notifications stopped working
 
 1. Make sure the plugin name is updated in `app.json` (Step 2)
 2. Rebuild with `npx expo prebuild --clean`
 3. Verify your Crisp Dashboard push notification settings are still configured
-
-### `openHelpdeskArticle` type error
-
-The method now takes an options object instead of positional arguments. See [Step 5](#step-5-update-changed-method-signatures).
 
 ---
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,484 @@
+# Migration Guide: `react-native-crisp-chat-sdk` → `expo-crisp-sdk`
+
+This guide helps you migrate from the legacy [`react-native-crisp-chat-sdk`](https://github.com/walterholohan/react-native-crisp-chat-sdk) to the official [`expo-crisp-sdk`](https://github.com/crisp-im/crisp-sdk-react-native).
+
+> **Requirements for `expo-crisp-sdk`:**
+>
+> - Expo SDK 53+ (or React Native 0.79+ with Expo Modules)
+> - New Architecture enabled (default in Expo SDK 53)
+> - Expo Go is **not** supported — use a [development build](https://docs.expo.dev/develop/development-builds/introduction/)
+
+---
+
+## Step 1: Update Dependencies
+
+Uninstall the old SDK and install the new one:
+
+```bash
+# Remove the old SDK
+yarn remove react-native-crisp-chat-sdk
+# or: npm uninstall react-native-crisp-chat-sdk
+
+# Install the new SDK
+npx expo install expo-crisp-sdk
+# or: yarn add expo-crisp-sdk
+```
+
+> **Note:** Keep `expo-build-properties` — it's still needed to set the iOS deployment target to 15.1+.
+
+---
+
+## Step 2: Update `app.json` / `app.config.js`
+
+Replace the plugin entry:
+
+**Before:**
+
+```json
+{
+  "expo": {
+    "plugins": [
+      ["expo-build-properties", { "ios": { "deploymentTarget": "15.1" } }],
+      [
+        "react-native-crisp-chat-sdk",
+        {
+          "websiteId": "YOUR_WEBSITE_ID",
+          "notifications": {
+            "enabled": true
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+**After:**
+
+```json
+{
+  "expo": {
+    "plugins": [
+      ["expo-build-properties", { "ios": { "deploymentTarget": "15.1" } }],
+      [
+        "expo-crisp-sdk",
+        {
+          "websiteId": "YOUR_WEBSITE_ID",
+          "notifications": {
+            "enabled": true,
+            "mode": "sdk-managed"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+**What changed:**
+
+| | Before | After |
+|---|---|---|
+| Plugin name | `"react-native-crisp-chat-sdk"` | `"expo-crisp-sdk"` |
+| Notification mode | _(not available)_ | `"sdk-managed"` or `"coexistence"` |
+
+> **Tip:** If your app uses another push notification system (e.g., `expo-notifications`, Firebase, OneSignal), use `"coexistence"` mode instead. See the [Push Notifications docs](./docs/PUSH_NOTIFICATIONS.md) for details.
+
+---
+
+## Step 3: Update Imports
+
+**Before:**
+
+```typescript
+import CrispChat, {
+  configure,
+  setTokenId,
+  setUserEmail,
+  setUserNickname,
+  setUserPhone,
+  setUserAvatar,
+  setUserCompany,
+  setSessionSegment,
+  setSessionSegments,
+  setSessionString,
+  setSessionBool,
+  setSessionInt,
+  getSessionIdentifier,
+  pushSessionEvent,
+  pushSessionEvents,
+  resetSession,
+  show,
+  searchHelpdesk,
+  openHelpdeskArticle,
+  runBotScenario,
+  CrispSessionEventColors,
+} from "react-native-crisp-chat-sdk";
+```
+
+**After:**
+
+```typescript
+import {
+  configure,
+  setTokenId,
+  setUserEmail,
+  setUserNickname,
+  setUserPhone,
+  setUserAvatar,
+  setUserCompany,
+  setSessionSegment,
+  setSessionSegments,
+  setSessionString,
+  setSessionBool,
+  setSessionInt,
+  getSessionIdentifier,
+  pushSessionEvent,
+  pushSessionEvents,
+  resetSession,
+  show,
+  searchHelpdesk,
+  openHelpdeskArticle,
+  runBotScenario,
+  CrispSessionEventColors,
+} from "expo-crisp-sdk";
+```
+
+**What changed:**
+
+- Package name: `"react-native-crisp-chat-sdk"` → `"expo-crisp-sdk"`
+- No more default export: `CrispChat` component is removed (see Step 4)
+
+---
+
+## Step 4: Remove the `<CrispChat />` Component
+
+The old SDK exported a `<CrispChat />` React component that called `show()` on mount. The new SDK removes this component — call `show()` directly instead.
+
+**Before:**
+
+```tsx
+import CrispChat, { configure } from "react-native-crisp-chat-sdk";
+
+export default function App() {
+  configure("YOUR_WEBSITE_ID");
+  return <CrispChat />;
+}
+```
+
+**After:**
+
+```tsx
+import { useEffect } from "react";
+import { Button, View } from "react-native";
+import { configure, show } from "expo-crisp-sdk";
+
+export default function App() {
+  useEffect(() => {
+    configure("YOUR_WEBSITE_ID");
+  }, []);
+
+  return (
+    <View>
+      <Button title="Chat with us" onPress={() => show()} />
+    </View>
+  );
+}
+```
+
+---
+
+## Step 5: Update Changed Method Signatures
+
+Most methods are **identical** between the two SDKs. Only three methods have changed:
+
+### `openHelpdeskArticle` — Now takes an options object
+
+**Before:**
+
+```typescript
+openHelpdeskArticle("article-slug", "en", "Getting Started", "Guides");
+```
+
+**After:**
+
+```typescript
+openHelpdeskArticle({
+  id: "article-slug",
+  locale: "en",
+  title: "Getting Started",   // optional
+  category: "Guides",         // optional
+});
+```
+
+### `setUserEmail` — Signature parameter is now optional
+
+**Before:**
+
+```typescript
+// Without verification — had to pass null explicitly
+setUserEmail("user@example.com", null);
+
+// With verification
+setUserEmail("user@example.com", "hmac-signature");
+```
+
+**After:**
+
+```typescript
+// Without verification — just omit the second argument
+setUserEmail("user@example.com");
+
+// With verification — same as before
+setUserEmail("user@example.com", "hmac-signature");
+```
+
+### `searchHelpdesk` — No longer auto-opens the chat
+
+**Before:** `searchHelpdesk()` automatically called `show()` internally.
+
+**After:** `searchHelpdesk()` only opens the helpdesk search. If the chat is not already visible, call `show()` yourself:
+
+```typescript
+searchHelpdesk();
+show(); // Add this if you need the chat to open
+```
+
+---
+
+## Step 6: Rebuild Your App
+
+After making all changes, rebuild your native projects:
+
+```bash
+npx expo prebuild --clean
+npx expo run:ios
+# or
+npx expo run:android
+```
+
+---
+
+## Step 7: Unchanged Methods (No Action Needed)
+
+These methods work exactly the same in both SDKs — no changes required:
+
+| Method | Signature |
+|---|---|
+| `configure` | `(websiteId: string) => void` |
+| `setTokenId` | `(tokenId: string \| null) => void` |
+| `setUserNickname` | `(name: string) => void` |
+| `setUserPhone` | `(phone: string) => void` |
+| `setUserAvatar` | `(url: string) => void` |
+| `setUserCompany` | `(company: Company) => void` |
+| `setSessionSegment` | `(segment: string) => void` |
+| `setSessionSegments` | `(segments: string[], overwrite?: boolean) => void` |
+| `setSessionString` | `(key: string, value: string) => void` |
+| `setSessionBool` | `(key: string, value: boolean) => void` |
+| `setSessionInt` | `(key: string, value: number) => void` |
+| `getSessionIdentifier` | `() => Promise<string \| null>` |
+| `pushSessionEvent` | `(name: string, color: CrispSessionEventColors) => void` |
+| `pushSessionEvents` | `(events: SessionEvent[]) => void` |
+| `resetSession` | `() => void` |
+| `show` | `() => void` |
+| `runBotScenario` | `(scenarioId: string) => void` |
+
+The `Company`, `Employment`, `Geolocation`, and `CrispSessionEventColors` types are also identical.
+
+---
+
+## New Features in `expo-crisp-sdk`
+
+The new SDK includes features that were not available in the legacy SDK:
+
+### Event Listeners
+
+Subscribe to chat events with the `useCrispEvents` hook:
+
+```typescript
+import { useCrispEvents } from "expo-crisp-sdk";
+
+useCrispEvents({
+  onSessionLoaded: (sessionId) => console.log("Session:", sessionId),
+  onChatOpened: () => console.log("Chat opened"),
+  onChatClosed: () => console.log("Chat closed"),
+  onMessageSent: (message) => console.log("Sent:", message.content),
+  onMessageReceived: (message) => console.log("Received:", message.content),
+});
+```
+
+### Show Messages
+
+Display messages programmatically as operator in the chatbox:
+
+```typescript
+import { showMessage } from "expo-crisp-sdk";
+
+showMessage({ type: "text", text: "Hello! How can I help?" });
+showMessage({
+  type: "picker",
+  id: "satisfaction",
+  text: "How satisfied are you?",
+  choices: [
+    { value: "happy", label: "Very satisfied" },
+    { value: "neutral", label: "Neutral" },
+    { value: "sad", label: "Not satisfied" },
+  ],
+});
+```
+
+### Debug Logging
+
+Enable native SDK logging for debugging:
+
+```typescript
+import { setLogLevel, CrispLogLevel, useCrispEvents } from "expo-crisp-sdk";
+
+setLogLevel(CrispLogLevel.DEBUG);
+
+useCrispEvents({
+  onLogReceived: (log) => {
+    console.log(`[Crisp] [${log.level}] ${log.tag}: ${log.message}`);
+  },
+});
+```
+
+### Push Notification Coexistence
+
+If your app uses another push notification system alongside Crisp:
+
+```typescript
+import { registerPushToken, isCrispPushNotification } from "expo-crisp-sdk";
+
+// Register a token from your notification system
+registerPushToken(expoPushToken);
+
+// Check if a notification is from Crisp
+const isCrisp = isCrispPushNotification(notificationData);
+```
+
+---
+
+## Complete Before/After Example
+
+### Before (legacy SDK)
+
+```tsx
+import CrispChat, {
+  configure,
+  setTokenId,
+  setUserEmail,
+  setUserNickname,
+  resetSession,
+  CrispSessionEventColors,
+  pushSessionEvent,
+  searchHelpdesk,
+  openHelpdeskArticle,
+} from "react-native-crisp-chat-sdk";
+
+export default function App() {
+  configure("YOUR_WEBSITE_ID");
+  setTokenId("user-123");
+  setUserEmail("user@example.com", null);
+  setUserNickname("John Doe");
+  pushSessionEvent("App opened", CrispSessionEventColors.BLUE);
+
+  const openHelp = () => {
+    openHelpdeskArticle("getting-started", "en", "Getting Started", null);
+  };
+
+  const onLogout = () => {
+    setTokenId(null);
+    resetSession();
+  };
+
+  return <CrispChat />;
+}
+```
+
+### After (new SDK)
+
+```tsx
+import { useEffect } from "react";
+import { Button, View } from "react-native";
+import {
+  configure,
+  setTokenId,
+  setUserEmail,
+  setUserNickname,
+  resetSession,
+  show,
+  CrispSessionEventColors,
+  pushSessionEvent,
+  searchHelpdesk,
+  openHelpdeskArticle,
+  useCrispEvents,
+} from "expo-crisp-sdk";
+
+export default function App() {
+  useEffect(() => {
+    configure("YOUR_WEBSITE_ID");
+    setTokenId("user-123");
+    setUserEmail("user@example.com");
+    setUserNickname("John Doe");
+    pushSessionEvent("App opened", CrispSessionEventColors.BLUE);
+  }, []);
+
+  useCrispEvents({
+    onMessageReceived: (message) => {
+      console.log("New message:", message.content);
+    },
+  });
+
+  const openHelp = () => {
+    openHelpdeskArticle({ id: "getting-started", locale: "en", title: "Getting Started" });
+  };
+
+  const onLogout = () => {
+    setTokenId(null);
+    resetSession();
+  };
+
+  return (
+    <View>
+      <Button title="Chat with us" onPress={() => show()} />
+      <Button title="Help Center" onPress={openHelp} />
+    </View>
+  );
+}
+```
+
+---
+
+## Troubleshooting
+
+### Build fails after migration
+
+Run a clean prebuild to regenerate native projects:
+
+```bash
+npx expo prebuild --clean
+```
+
+### `CrispChat` is not exported
+
+The `<CrispChat />` component has been removed. Use `show()` to open the chat instead. See [Step 4](#step-4-remove-the-crispchat--component).
+
+### Push notifications stopped working
+
+1. Make sure the plugin name is updated in `app.json` (Step 2)
+2. Rebuild with `npx expo prebuild --clean`
+3. Verify your Crisp Dashboard push notification settings are still configured
+
+### `openHelpdeskArticle` type error
+
+The method now takes an options object instead of positional arguments. See [Step 5](#step-5-update-changed-method-signatures).
+
+---
+
+## Need Help?
+
+- [expo-crisp-sdk README](./README.md) — Full API reference and usage examples
+- [Push Notifications Guide](./docs/PUSH_NOTIFICATIONS.md) — Detailed push notification setup
+- [Crisp Developer Documentation](https://docs.crisp.chat/) — Official Crisp docs
+- [GitHub Issues](https://github.com/crisp-im/crisp-sdk-react-native/issues) — Report bugs or ask questions

--- a/README.md
+++ b/README.md
@@ -165,8 +165,7 @@ To use the Crisp SDK, you need your Website ID from the Crisp Dashboard.
 3. Copy your Website ID
 
 <p align="center">
-  <em><img width="1575" height="870" alt="Configure_ID" src="https://github.com/user-attachments/assets/b4c37b71-a29f-4675-9831-fb0e5823cb70" /></em>
-
+  <em><img width="1797" height="872" alt="Setup and Integrations" src="https://github.com/user-attachments/assets/a68dd11e-84ed-4e9f-a68c-ec63fc58c61a" /></em>
 </p>
 
 ### Initialize Crisp

--- a/README.md
+++ b/README.md
@@ -550,10 +550,10 @@ Access your knowledge base:
 ```typescript
 import { searchHelpdesk, openHelpdeskArticle } from "expo-crisp-sdk";
 
-// Open helpdesk search
+// Open helpdesk search (automatically opens the chat)
 searchHelpdesk();
 
-// Open a specific article
+// Open a specific article (automatically opens the chat)
 openHelpdeskArticle({
   id: "getting-started",
   locale: "en",
@@ -661,8 +661,8 @@ Available log levels (from most to least verbose):
 | Method                                               | Description                         | Parameters                                                                      | Return |
 | ---------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------- | ------ |
 | `show()`                                             | Open the Crisp chat widget.         | -                                                                               | `void` |
-| `searchHelpdesk()`                                   | Open the helpdesk search interface. | -                                                                               | `void` |
-| `openHelpdeskArticle(options)` | Open a specific helpdesk article.   | `options: HelpdeskArticleOptions` | `void` |
+| `searchHelpdesk()`                                   | Open the helpdesk search interface and the chat widget. | -                                                                               | `void` |
+| `openHelpdeskArticle(options)` | Open a specific helpdesk article and the chat widget.   | `options: HelpdeskArticleOptions` | `void` |
 | `runBotScenario(scenarioId)`                         | Trigger an automated bot scenario.  | `scenarioId: string`                                                            | `void` |
 
 ### Push Notification Methods (Coexistence Mode)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 > [!WARNING]
 > **Expo SDK 53+ Required**
 >
-> This SDK is exclusively compatible with Expo SDK version 53 and newer. For projects using older Expo versions, please use the [legacy React Native SDK](https://github.com/walterholohan/react-native-crisp-chat-sdk).
+> This SDK is exclusively compatible with Expo SDK version 53 and newer. For projects using older Expo versions, please use the [legacy React Native SDK](https://github.com/walterholohan/react-native-crisp-chat-sdk). If you're migrating from the legacy SDK, see the [Migration Guide](./MIGRATION.md).
 
 > [!WARNING]
 > **Expo Go is Not Supported**

--- a/docs/PUSH_NOTIFICATIONS.md
+++ b/docs/PUSH_NOTIFICATIONS.md
@@ -81,11 +81,11 @@ Apple maintains two completely separate push notification environments:
 
 1. Go to [Crisp Dashboard](https://app.crisp.chat)
 
-2. Navigate to **Settings** > **Chatbox** > **Push Notifications**
+2. Navigate to **Settings** > **Chatbox Settings** > **Push Notifications**
+   
+   <img width="1789" height="864" alt="Push Notifs " src="https://github.com/user-attachments/assets/3f375634-f607-4055-8de0-13ad03408126" />
 
-   <img width="1635" height="965" alt="Configure-Dashboard-APNs-key" src="https://github.com/user-attachments/assets/1e295575-0663-49a8-8c36-db7b39d9aa43" />
-
-3. In the iOS section, provide the following information:
+4. In the iOS section, provide the following information:
 
    | Field           | Description                                          | Where to find it                                                                                                                      |
    | --------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
@@ -94,9 +94,9 @@ Apple maintains two completely separate push notification environments:
    | **Bundle ID**   | Your app's bundle identifier                         | Defined in your `app.json` (`expo.ios.bundleIdentifier`) or Xcode project settings                                                    |
    | **Key ID**      | The APNs key identifier (10 characters)              | Shown after creating the key, or in your Keys list                                                                                    |
 
-4. If you want to test with development builds, enable the **Sandbox mode** toggle in Crisp Dashboard
+5. If you want to test with development builds, enable the **Sandbox mode** toggle in Crisp Dashboard
 
-5. Click **Verify** to validate your credentials
+6. Click **Verify** to validate your credentials
 
 ### Step 5: Verify Xcode Configuration
 
@@ -224,7 +224,7 @@ Now that your app is registered, you need to get two pieces of information from 
 
 3. In the **Cloud Messaging** tab, find the **Sender ID**
 
-   <img width="1161" height="579" alt="Firebase Sender ID" src="https://github.com/user-attachments/assets/9f33214a-b9f0-4ab0-a2c3-2e240cf1348b" />
+   <img width="1294" height="416" alt="Firebase Cloud Messaging" src="https://github.com/user-attachments/assets/4714e4a2-4520-447d-bef1-74819de458fb" />
 
 > [!NOTE]
 > The "Sender ID" IS your Project Number. Firebase uses these terms interchangeably.
@@ -241,7 +241,7 @@ Now that your app is registered, you need to get two pieces of information from 
 
 4. A JSON file will be downloaded automatically
 
-   <img width="1142" height="748" alt="Generate Firebase Private Key" src="https://github.com/user-attachments/assets/ed60751e-3888-4b12-96bb-862e9cb4f8d4" />
+   <img width="1320" height="847" alt="Firebase Service Accounts" src="https://github.com/user-attachments/assets/3fe1ae89-dbdd-4ac7-b325-88ab73820657" />
 
 > [!WARNING]
 > Store this private key securely. It grants access to your Firebase project and should never be committed to version control or shared publicly.
@@ -264,8 +264,6 @@ With your Firebase credentials ready, let's configure Crisp to send push notific
 4. Click **Verify** to validate your credentials
 
 5. If verification succeeds, the status will show as **live**
-
-   <img width="1908" height="871" alt="Crisp Dashboard Android Configuration" src="https://github.com/user-attachments/assets/18758630-cb06-452b-a613-213eec4b1f5c" />
 
 ### Step 6: Configure Your Project
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { createElement, useEffect } from "react";
+import { View } from "react-native";
 import type {
   Company,
   CrispLogLevel,
@@ -13,6 +15,34 @@ export * from "./ExpoCrispSdk.types";
 export type { CrispEventCallbacks } from "./useCrispEvents";
 export { useCrispEvents } from "./useCrispEvents";
 export { getSDKVersion } from "./version";
+
+// ============================================================================
+// Legacy Compatibility
+// ============================================================================
+
+/**
+ * Legacy React component that opens the Crisp chat on mount.
+ *
+ * @deprecated Use `show()` directly instead. This component will be removed in a future version.
+ *
+ * @example
+ * // Before (deprecated)
+ * import CrispChat from "expo-crisp-sdk";
+ * <CrispChat />
+ *
+ * // After (recommended)
+ * import { show } from "expo-crisp-sdk";
+ * show();
+ */
+const CrispChat = () => {
+  useEffect(() => {
+    ExpoCrispSdkModule.show();
+  }, []);
+
+  return createElement(View);
+};
+
+export default CrispChat;
 
 // ============================================================================
 // Configuration
@@ -212,23 +242,43 @@ export function show(): void {
 
 /**
  * Open the helpdesk search interface.
+ * Automatically opens the chat widget after searching.
  */
 export function searchHelpdesk(): void {
   ExpoCrispSdkModule.searchHelpdesk();
+  ExpoCrispSdkModule.show();
 }
 
 /**
  * Open a specific helpdesk article.
+ * Automatically opens the chat widget after opening the article.
  *
- * @param options - Article options including id, locale, and optional title/category
+ * Accepts both the new object format and the legacy positional arguments:
+ *
+ * @example
+ * // New format (recommended)
+ * openHelpdeskArticle({ id: "slug", locale: "en", title: "Title", category: "Cat" });
+ *
+ * // Legacy format (deprecated, for backward compatibility)
+ * openHelpdeskArticle("slug", "en", "Title", "Cat");
  */
-export function openHelpdeskArticle(options: HelpdeskArticleOptions): void {
-  ExpoCrispSdkModule.openHelpdeskArticle(
-    options.id,
-    options.locale,
-    options.title,
-    options.category,
-  );
+export function openHelpdeskArticle(
+  optionsOrId: HelpdeskArticleOptions | string,
+  locale?: string,
+  title?: string | null,
+  category?: string | null,
+): void {
+  if (typeof optionsOrId === "string") {
+    ExpoCrispSdkModule.openHelpdeskArticle(optionsOrId, locale!, title, category);
+  } else {
+    ExpoCrispSdkModule.openHelpdeskArticle(
+      optionsOrId.id,
+      optionsOrId.locale,
+      optionsOrId.title,
+      optionsOrId.category,
+    );
+  }
+  ExpoCrispSdkModule.show();
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `MIGRATION.md` with step-by-step instructions for users migrating from `react-native-crisp-chat-sdk` to `expo-crisp-sdk`
- Add link to migration guide in README warning banner
- Include changeset for release note

## Migration Guide Covers

- **Installation**: uninstall old, install new
- **Config plugin**: `react-native-crisp-chat-sdk` → `expo-crisp-sdk` in app.json
- **Imports**: package name change, no more default export
- **Removed `<CrispChat />` component**: replaced by `show()` call
- **3 API changes**:
  - `openHelpdeskArticle` now takes an options object instead of positional args
  - `setUserEmail` signature parameter is now optional
  - `searchHelpdesk` no longer auto-calls `show()`
- **New features**: `useCrispEvents`, `showMessage`, `setLogLevel`, coexistence mode
- **Complete before/after example**
- **Troubleshooting** section

## Context

This enables Crisp to npm-deprecate the legacy `react-native-crisp-chat-sdk` package by providing clear migration instructions for existing users.

## Test plan

- [ ] Verify all code examples compile correctly
- [ ] Verify all links resolve (MIGRATION.md, PUSH_NOTIFICATIONS.md)
- [ ] Cross-check API changes against actual source code