### PR TITLE
feat(android): emit onPushNotificationReceived in coexistence mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ const isCrisp = isCrispPushNotification(notificationData);
 setShouldPromptForNotificationPermission(false);
 ```
 
-**Listen for Crisp notifications in the foreground (iOS only):**
+**Listen for Crisp notifications in the foreground:**
 
 ```typescript
 import { useCrispEvents } from "crisp-sdk-react-native";
@@ -313,7 +313,7 @@ useCrispEvents({
 ```
 
 > [!NOTE]
-> `onPushNotificationReceived` is currently **iOS only**. On Android, the Crisp SDK does not expose a foreground notification callback — notifications are handled entirely at the native `FirebaseMessagingService` level.
+> `onPushNotificationReceived` fires on iOS in both notification modes, and on Android only in **coexistence mode**. In Android `sdk-managed` mode, notifications are handled inside the Crisp Android library's own `FirebaseMessagingService`, which has no hook for emitting JS events.
 
 > [!NOTE]
 > In coexistence mode, the native routing is automatic — you don't need to write JS filtering code. The JS API methods (`registerPushToken`, `isCrispPushNotification`) are optional utilities for advanced use cases.
@@ -857,7 +857,7 @@ interface CrispEventCallbacks {
   onChatClosed?: () => void;
   onMessageSent?: (message: CrispMessage) => void;
   onMessageReceived?: (message: CrispMessage) => void;
-  onPushNotificationReceived?: (notification: PushNotificationPayload) => void; // iOS only
+  onPushNotificationReceived?: (notification: PushNotificationPayload) => void;
   onLogReceived?: (log: CrispLogEntry) => void;
 }
 ```
@@ -880,7 +880,7 @@ interface MessagePayload {
 // Empty payload for onChatOpened and onChatClosed callbacks
 type EmptyPayload = Record<string, never>;
 
-// Payload for onPushNotificationReceived callback (iOS only)
+// Payload for onPushNotificationReceived callback
 interface PushNotificationPayload {
   title: string;
   body: string;

--- a/android/src/main/java/expo/modules/crispsdk/CrispPushEventEmitter.kt
+++ b/android/src/main/java/expo/modules/crispsdk/CrispPushEventEmitter.kt
@@ -1,0 +1,45 @@
+package expo.modules.crispsdk
+
+import android.util.Log
+
+/**
+ * Bridges the generated ExpoCrispFirebaseMessagingService (coexistence
+ * mode) to the ExpoCrispSdkModule's event system so push notifications
+ * can be forwarded to JS via `onPushNotificationReceived`. Mirrors the
+ * iOS-side `CrispNotificationEventEmitter` pattern.
+ *
+ * `sendEvent` is installed in `ExpoCrispSdkModule.OnCreate` and cleared
+ * in `OnDestroy`. Calls that arrive when the module is not active (e.g.
+ * app killed/backgrounded, or before `OnCreate` during cold start) are
+ * safe no-ops via the `?.invoke` null-safety operator.
+ *
+ * Thread safety: `sendEvent` is written from the main thread (the
+ * module's `OnCreate`/`OnDestroy`) and read from the FCM service worker
+ * thread (`onMessageReceived`). `@Volatile` guarantees memory visibility
+ * across threads — without it the FCM thread could read a stale cached
+ * null and silently drop events. The null-safe call reads the var once
+ * before invoking, so there's no race between null-check and invocation.
+ */
+object CrispPushEventEmitter {
+    private const val TAG = "CrispPushEventEmitter"
+
+    @Volatile
+    var sendEvent: ((name: String, body: Map<String, Any?>) -> Unit)? = null
+
+    fun emitPushNotificationReceived(title: String, body: String) {
+        // Best-effort emit. The FCM service worker thread must not let
+        // exceptions propagate back to FCM — that would mark the message
+        // as failed and could trigger redelivery. The OS notification has
+        // already been posted by CrispNotificationClient.handleNotification(...)
+        // before this is called, so a failure here only loses the JS
+        // event, never the user-facing alert.
+        try {
+            sendEvent?.invoke("onPushNotificationReceived", mapOf(
+                "title" to title,
+                "body" to body
+            ))
+        } catch (e: Throwable) {
+            Log.w(TAG, "Failed to emit onPushNotificationReceived to JS", e)
+        }
+    }
+}

--- a/android/src/main/java/expo/modules/crispsdk/ExpoCrispSdkModule.kt
+++ b/android/src/main/java/expo/modules/crispsdk/ExpoCrispSdkModule.kt
@@ -43,11 +43,18 @@ class ExpoCrispSdkModule : Module() {
     OnCreate {
       registerEventsCallback()
       registerLogger()
+      // Wire the push-event singleton so the generated FCM service
+      // (coexistence mode) can emit onPushNotificationReceived to JS.
+      // Mirrors iOS's setupNotificationEventEmitter().
+      CrispPushEventEmitter.sendEvent = { eventName, data ->
+        this@ExpoCrispSdkModule.sendEvent(eventName, data)
+      }
     }
 
     OnDestroy {
       unregisterEventsCallback()
       unregisterLogger()
+      CrispPushEventEmitter.sendEvent = null
     }
 
     // MARK: - Configuration

--- a/plugin/src/withAndroid.ts
+++ b/plugin/src/withAndroid.ts
@@ -133,12 +133,24 @@ function generateFirebaseMessagingService(packageName: string): string {
 
 import com.google.firebase.messaging.RemoteMessage
 import im.crisp.client.external.notification.CrispNotificationClient
+import expo.modules.crispsdk.CrispPushEventEmitter
 
 class ExpoCrispFirebaseMessagingService : ${baseClass}() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         if (CrispNotificationClient.isCrispNotification(message)) {
             CrispNotificationClient.handleNotification(this, message)
+            // Forward title/body to JS for parity with iOS's
+            // onPushNotificationReceived. Falls back through the
+            // data payload (Crisp uses data-only pushes) then the
+            // FCM notification block, then empty.
+            val title = message.data["title"]
+                ?: message.notification?.title
+                ?: ""
+            val body = message.data["body"]
+                ?: message.notification?.body
+                ?: ""
+            CrispPushEventEmitter.emitPushNotificationReceived(title, body)
         } else {
             super.onMessageReceived(message)
         }


### PR DESCRIPTION
# Add Android support for `onPushNotificationReceived` (coexistence mode)

## Motivation

`onPushNotificationReceived` currently fires only on iOS — the README spells this out as a hard limitation. This blocks Android apps from reflecting incoming admin messages in their own in-app UI (badge counts, attention indicators, etc.) while the chatbox is closed. Today, the OS notification banner is the only signal Android users get.

The infrastructure for the event is already in place on the Android side — `ExpoCrispSdkModule.kt` declares `onPushNotificationReceived` in its `Events(...)` block — but nothing fires it. This PR wires it up.

## Scope

- **Coexistence mode only.** The generated `ExpoCrispFirebaseMessagingService` lives in the consumer's app sources, so the plugin can control its behavior. `sdk-managed` mode routes through `im.crisp.client.external.notification.CrispNotificationService` inside the `im.crisp:crisp-sdk` Android library, which this PR doesn't touch.
- **iOS unchanged.** iOS already emits the event via `CrispNotificationEventEmitter.shared.emitPushNotificationReceived(...)` from `CrispAppDelegateSubscriber.swift`. This PR mirrors that pattern on Android.

## Changes

### 1. New file: `android/src/main/java/expo/modules/crispsdk/CrispPushEventEmitter.kt`

Singleton that holds a `sendEvent` lambda the generated FCM service can call. Mirrors `ios/CrispNotificationEventEmitter.swift`. `@Volatile` is needed because `sendEvent` is written from the main thread (the module's `OnCreate`/`OnDestroy`) and read from the FCM service worker thread (`onMessageReceived`). The emit is wrapped in `try`/`catch` so failures inside JS dispatch can never bubble back to FCM and trigger redelivery — the OS banner has already been posted by `CrispNotificationClient.handleNotification(...)` before this method runs.

### 2. Modify `android/src/main/java/expo/modules/crispsdk/ExpoCrispSdkModule.kt`

Wire the singleton from `OnCreate` (mirrors iOS's `setupNotificationEventEmitter()`):

```kotlin
OnCreate {
  registerEventsCallback()
  registerLogger()
  CrispPushEventEmitter.sendEvent = { eventName, data ->
    this@ExpoCrispSdkModule.sendEvent(eventName, data)
  }
}

OnDestroy {
  unregisterEventsCallback()
  unregisterLogger()
  CrispPushEventEmitter.sendEvent = null
}
```

### 3. Modify `plugin/src/withAndroid.ts` — `generateFirebaseMessagingService(...)`

Append the JS-event emission to the Crisp-handling branch of the generated service:

```kotlin
override fun onMessageReceived(message: RemoteMessage) {
    if (CrispNotificationClient.isCrispNotification(message)) {
        CrispNotificationClient.handleNotification(this, message)
        val title = message.data["title"]
            ?: message.notification?.title
            ?: ""
        val body = message.data["body"]
            ?: message.notification?.body
            ?: ""
        CrispPushEventEmitter.emitPushNotificationReceived(title, body)
    } else {
        super.onMessageReceived(message)
    }
}
```

The generated service is in the consumer's package (e.g. `com.example.app.ExpoCrispFirebaseMessagingService`), so an explicit `import expo.modules.crispsdk.CrispPushEventEmitter` is added at the top of the template.

### 4. README

Removed the iOS-only caveat around `onPushNotificationReceived` and added a note clarifying that Android support requires **coexistence mode**.

## Backward compatibility

- Adding a new file: no impact.
- Wiring the singleton in `OnCreate`/`OnDestroy`: idempotent — overwrites the lambda on each module instance, cleared on destroy.
- Modifying the generated service: only affects users running `expo prebuild` against the new SDK version; the addition is additive (only adds emit, doesn't change existing Crisp-handling behavior).

## Testing

- **iOS** — no changes; existing behavior preserved.
- **Android (coexistence mode)** — operator sends a message → device receives FCM push → `CrispNotificationClient.handleNotification` posts the OS banner as before → `CrispPushEventEmitter` fires → JS receives `onPushNotificationReceived` with `{ title, body }`. Verified end-to-end on a physical Android device against a production Crisp workspace.
- **Android (sdk-managed mode)** — no change in behavior; the hardcoded `CrispNotificationService` inside the `im.crisp:crisp-sdk` library has no hook to emit the event, so it remains a no-op there (and is documented as such).

## Open question for maintainers

Would the Crisp team be open to also wiring this in **sdk-managed** mode? That would require a change inside the `im.crisp:crisp-sdk` Android library — exposing a hook from `CrispNotificationService` after a notification is handled, then having this React Native module subscribe to it. Smaller surface area for consumers (no need to switch to coexistence), but more invasive on the underlying SDK. Happy to follow up with a separate PR if there's interest.
