### PR TITLE
feat(notifications): open the chatbox on iOS push notification tap

### DIFF
--- a/.changeset/open-chatbox-on-notification-tap.md
+++ b/.changeset/open-chatbox-on-notification-tap.md
@@ -1,0 +1,5 @@
+---
+"crisp-sdk-react-native": minor
+---
+
+Open the Crisp chatbox when a user taps a Crisp push notification on iOS. Previously the tap brought the app to the foreground but left the message hidden in the closed chatbox, because the iOS SDK's `handlePushNotification` only performs bookkeeping and the notification-tap delegate never presented the chat. It now presents `ChatViewController` on the top-most view controller (in both notification modes). Android already opens the chatbox on tap via the SDK's own back-stacked `ChatActivity` intent, so no Android change is needed.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,14 @@ To enable push notifications, add the config plugin to your `app.json` or `app.c
 > [!NOTE]
 > After enabling notifications, rebuild your app with `npx expo prebuild --clean` followed by `npx expo run:ios` or `npx expo run:android`.
 
+> [!NOTE]
+> On iOS, tapping a Crisp push notification opens the chatbox: the
+> notification-tap delegate presents `ChatViewController` (in both notification
+> modes). Previously the tap brought the app to the foreground but left the
+> message hidden in the closed chatbox. On Android this already works out of the
+> box — the Crisp SDK's notification opens `ChatActivity` directly via its own
+> back-stacked intent — so no extra handling is required.
+
 #### Crisp Dashboard Configuration
 
 Push notifications require additional setup in your Crisp Dashboard (APNs for iOS, Firebase for Android).

--- a/ios/CrispAppDelegateSubscriber.swift
+++ b/ios/CrispAppDelegateSubscriber.swift
@@ -63,7 +63,9 @@ public class CrispAppDelegateSubscriber: ExpoAppDelegateSubscriber {
   // MARK: - Chatbox Presentation (notification tap)
 
   /// Presents the Crisp chatbox modally on the top-most view controller —
-  /// the same `ChatViewController` the module's `show()` function uses.
+  /// the same `ChatViewController` the module's `show()` function uses —
+  /// after selecting the "Chat" tab via `CrispSDK.openChat()` so the tapped
+  /// notification lands on the conversation.
   /// Walks the `presentedViewController` chain so it works even when another
   /// modal is already on screen, and no-ops if a chatbox is anywhere in the
   /// chain (the chat may itself have presented a child controller, e.g. an
@@ -79,6 +81,11 @@ public class CrispAppDelegateSubscriber: ExpoAppDelegateSubscriber {
       }
       // Don't present onto a controller mid-transition — UIKit would drop it.
       guard !topViewController.isBeingPresented, !topViewController.isBeingDismissed else { return }
+      // Select the "Chat" tab before presenting so the tapped notification opens
+      // on the conversation rather than the Helpdesk tab. `openChat()` only sets
+      // the active tab for the next presentation — it does not present anything
+      // itself — so the explicit `present` below is still required.
+      CrispSDK.openChat()
       topViewController.present(ChatViewController(), animated: true)
     }
   }

--- a/ios/CrispAppDelegateSubscriber.swift
+++ b/ios/CrispAppDelegateSubscriber.swift
@@ -59,6 +59,36 @@ public class CrispAppDelegateSubscriber: ExpoAppDelegateSubscriber {
     // Set ourselves as the delegate
     center.delegate = self
   }
+
+  // MARK: - Chatbox Presentation (notification tap)
+
+  /// Presents the Crisp chatbox modally on the top-most view controller —
+  /// the same `ChatViewController` the module's `show()` function uses.
+  /// Walks the `presentedViewController` chain so it works even when another
+  /// modal is already on screen, and no-ops if a chatbox is anywhere in the
+  /// chain (the chat may itself have presented a child controller, e.g. an
+  /// image/attachment preview) or if a transition is in flight.
+  fileprivate static func presentChatbox() {
+    DispatchQueue.main.async {
+      guard var topViewController = keyWindow()?.rootViewController else { return }
+      // No-op if a Crisp chatbox is already anywhere in the presentation chain.
+      if topViewController is ChatViewController { return }
+      while let presented = topViewController.presentedViewController {
+        if presented is ChatViewController { return }
+        topViewController = presented
+      }
+      // Don't present onto a controller mid-transition — UIKit would drop it.
+      guard !topViewController.isBeingPresented, !topViewController.isBeingDismissed else { return }
+      topViewController.present(ChatViewController(), animated: true)
+    }
+  }
+
+  private static func keyWindow() -> UIWindow? {
+    return UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .flatMap { $0.windows }
+      .first { $0.isKeyWindow }
+  }
 }
 
 // MARK: - UNUserNotificationCenterDelegate (Coexistence Mode)
@@ -100,6 +130,13 @@ extension CrispAppDelegateSubscriber: UNUserNotificationCenterDelegate {
     if CrispSDK.isCrispPushNotification(notification) {
       // Handle Crisp notification tap (both modes)
       CrispSDK.handlePushNotification(notification)
+
+      // Open the chatbox so the tapped conversation is actually shown.
+      // `handlePushNotification` only performs SDK bookkeeping; without an
+      // explicit present, tapping a Crisp notification brings the app to the
+      // foreground but leaves the message hidden in the closed chatbox.
+      Self.presentChatbox()
+
       completionHandler()
     } else if isCoexistenceMode, let previous = previousDelegate {
       // In coexistence mode, forward non-Crisp notification taps to the previous delegate


### PR DESCRIPTION
## Summary

Open the Crisp chatbox when the user **taps** a Crisp push notification on **iOS**.

Today on iOS, tapping a Crisp notification brings the app to the foreground but leaves the message hidden in the closed chatbox. The wrapper's notification-tap delegate (`userNotificationCenter(_:didReceive:withCompletionHandler:)`) calls `CrispSDK.handlePushNotification(...)` (SDK bookkeeping only — the foreground `willPresent` path also calls it and then just shows a banner) and never presents the chat.

This is the natural counterpart to #29, which wired the foreground `onPushNotificationReceived` event: #29 handled *received-while-open*; this handles *tapped-while-closed*.

> **Android needs no change.** I checked the Android SDK (`crisp-sdk` 2.0.18): both notification modes call `CrispNotificationClient.handleNotification(ctx, msg)` (`openChatbox=true`), whose content `PendingIntent` is a `TaskStackBuilder` of `[launcher activity, ChatActivity(sender=crisp)]` — so a tap already opens `ChatActivity` directly via the SDK. The gap is iOS-only.

## Changes (iOS only)

`ios/CrispAppDelegateSubscriber.swift` — after `handlePushNotification` in the tap delegate, present `ChatViewController` on the top-most view controller (mirroring the module's existing `show()`). A small helper:
- walks the `presentedViewController` chain and **no-ops if a chatbox is anywhere in it** (the chat can itself present a child VC, e.g. an image/attachment preview, so checking only the top-most node would double-present);
- **bails if a transition is in flight** (`isBeingPresented` / `isBeingDismissed`), which UIKit would otherwise drop with a warning.

This runs in **both** notification modes (the Crisp-notification branch precedes the coexistence check), which is intended — `handlePushNotification` is bookkeeping-only in both modes, so the explicit present is always needed on iOS.

`README.md` + `.changeset/` — document the behavior (iOS opens chat on tap; Android already does via the SDK).

## Design note

This auto-presents the chatbox on tap (what most apps want, and what the SDK's bookkeeping call implies). If you'd prefer the wrapper to instead emit a JS event (e.g. `onPushNotificationTapped`) and let the host navigate, I'm happy to switch — just say which you prefer.

## Testing

Running in production in a shipping app (1fifty), verified end-to-end on a physical iOS device in both notification modes: operator message → background the app → tap the notification → the chatbox opens to the conversation.

## Backward compatibility

Additive, iOS-only. No public API or config changes; notification receipt and the existing `show()` are unchanged — only the previously-no-op tap path now presents the chat.

## Notes for reviewers

- The new key-window lookup mirrors the one in `findRootViewController()` (`ExpoCrispSdkModule.swift`); kept inline to avoid pulling in a shared util in this small PR — happy to extract a shared helper if you prefer.
- `presentChatbox()` is actually more robust than the existing `show()` (which presents off the root VC and can fail when a modal is already up). Unifying `show()` onto the same logic is a sensible follow-up; left out here to keep the PR focused. (I also have a couple of small standalone `registerPushToken` robustness fixes I can send separately.)
