### PR TITLE
fix(ios): harden registerPushToken (empty token unregisters, strict hex)

### DIFF
--- a/.changeset/registerpushtoken-robustness.md
+++ b/.changeset/registerpushtoken-robustness.md
@@ -1,0 +1,8 @@
+---
+"crisp-sdk-react-native": patch
+---
+
+Harden iOS `registerPushToken`:
+
+- An empty string now **unregisters** by clearing the device token (`CrispSDK.setDeviceToken(Data())`) instead of early-returning — previously there was no way to unregister a push token through the wrapper (e.g. on notification opt-out).
+- The hex APNs token is parsed strictly: it throws on odd-length or non-hex input instead of silently skipping invalid bytes and registering a truncated token with no error surfaced to the caller.

--- a/ios/ExpoCrispSdkModule.swift
+++ b/ios/ExpoCrispSdkModule.swift
@@ -158,15 +158,36 @@ public class ExpoCrispSdkModule: Module {
     // MARK: - Push Notifications (Coexistence Mode)
 
     Function("registerPushToken") { (token: String) in
-      guard !token.isEmpty else { return }
-      // Convert hex string to Data
-      var data = Data()
-      var index = token.startIndex
-      while index < token.endIndex {
-        let nextIndex = token.index(index, offsetBy: 2, limitedBy: token.endIndex) ?? token.endIndex
-        if let byte = UInt8(token[index..<nextIndex], radix: 16) {
-          data.append(byte)
+      // An empty token means "unregister": clear the device token so Crisp
+      // stops routing pushes to this device. Previously this early-returned,
+      // leaving callers no way to unregister a token through the wrapper.
+      let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+      if trimmed.isEmpty {
+        CrispSDK.setDeviceToken(Data())
+        return
+      }
+
+      // Parse the hex APNs token strictly. The previous parser silently
+      // skipped invalid bytes and accepted odd-length input, which would hand
+      // Crisp a truncated/garbage token with no error surfaced to the caller.
+      guard trimmed.count % 2 == 0 else {
+        throw NSError(
+          domain: "ExpoCrispSdk", code: 100,
+          userInfo: [NSLocalizedDescriptionKey: "registerPushToken: hex token has odd length (\(trimmed.count))"]
+        )
+      }
+      var data = Data(capacity: trimmed.count / 2)
+      var index = trimmed.startIndex
+      while index < trimmed.endIndex {
+        let nextIndex = trimmed.index(index, offsetBy: 2)
+        let byteString = trimmed[index..<nextIndex]
+        guard let byte = UInt8(byteString, radix: 16) else {
+          throw NSError(
+            domain: "ExpoCrispSdk", code: 101,
+            userInfo: [NSLocalizedDescriptionKey: "registerPushToken: invalid hex byte \"\(byteString)\""]
+          )
         }
+        data.append(byte)
         index = nextIndex
       }
       CrispSDK.setDeviceToken(data)


### PR DESCRIPTION
## Summary

Two small robustness fixes to iOS `registerPushToken` (`ios/ExpoCrispSdkModule.swift`). Follow-up to #33 (mentioned there as standalone fixes).

### 1. Empty token should unregister

```swift
guard !token.isEmpty else { return }   // before: empty input is a no-op
```

Today, passing an empty string early-returns, so **there is no way to unregister a push token** through the wrapper (e.g. when a user opts out of notifications and you want Crisp to stop routing pushes to the device). The fix treats an empty/whitespace token as "unregister" and clears the device token via `CrispSDK.setDeviceToken(Data())`.

### 2. Strict hex parsing

The previous parser silently skipped invalid bytes and accepted odd-length input:

```swift
if let byte = UInt8(token[index..<nextIndex], radix: 16) {
  data.append(byte)   // invalid byte → silently dropped
}
```

A malformed token would register a **truncated/garbage** device token with no error surfaced to the caller. The fix throws on odd-length or non-hex input (valid APNs tokens are 64 hex chars), so a bad token fails loudly instead of half-registering.

## Testing

Both behaviors run in production in a shipping app (1fifty): the empty-token path is used to clear registration on notification opt-out; the strict parse guards the bridge boundary. Verified on a physical iOS device.

## Backward compatibility

- Strict hex parsing: a previously-malformed token now throws instead of silently registering a truncated one. Well-formed tokens are unaffected.
- Empty token: previously a no-op, now clears the device token. If any caller relied on `registerPushToken('')` doing nothing, that changes — but a no-op on empty was almost certainly unintended (there was no other way to unregister).

Android's `registerPushToken` has the same `if (token.isNotEmpty())` early-return, but I left it out of this PR because the Android Crisp SDK has no obvious public "clear token" call to mirror `setDeviceToken(Data())`; happy to address it too if you can point me at the right API.
