### PR TITLE
fix(android): resolve commonmark dependency conflict

### DIFF
--- a/.changeset/fix-android-commonmark-conflict.md
+++ b/.changeset/fix-android-commonmark-conflict.md
@@ -1,0 +1,5 @@
+---
+"crisp-sdk-react-native": patch
+---
+
+Fix Android dependency resolution by excluding the CommonMark version pulled by the Crisp Android SDK and pinning a compatible CommonMark dependency.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,5 +14,8 @@ android {
 }
 
 dependencies {
-  implementation "im.crisp:crisp-sdk:2.0.21"
+  implementation("im.crisp:crisp-sdk:2.0.21") {
+    exclude group: "com.atlassian.commonmark", module: "commonmark"
+  }
+  implementation "org.commonmark:commonmark:0.21.0"
 }

--- a/plugin/src/withAndroid.ts
+++ b/plugin/src/withAndroid.ts
@@ -15,6 +15,44 @@ type AndroidNotificationConfig = {
   mode: NotificationMode;
 };
 
+const CRISP_ANDROID_SDK_DEPENDENCY = `implementation('im.crisp:crisp-sdk:2.0.21') {
+        exclude group: 'com.atlassian.commonmark', module: 'commonmark'
+    }`;
+const COMMONMARK_ANDROID_DEPENDENCY = "implementation 'org.commonmark:commonmark:0.21.0'";
+const CRISP_COMMONMARK_EXCLUSION =
+  "exclude group: 'com.atlassian.commonmark', module: 'commonmark'";
+
+function addCrispAndroidSdkDependency(contents: string): string {
+  if (!contents.includes("im.crisp:crisp-sdk")) {
+    return contents.replace(
+      /dependencies\s*\{/,
+      `dependencies {
+    ${CRISP_ANDROID_SDK_DEPENDENCY}`,
+    );
+  }
+
+  if (contents.includes(CRISP_COMMONMARK_EXCLUSION)) {
+    return contents;
+  }
+
+  return contents.replace(
+    /implementation\s+['"]im\.crisp:crisp-sdk:2\.0\.21['"]/,
+    CRISP_ANDROID_SDK_DEPENDENCY,
+  );
+}
+
+function addCommonmarkAndroidDependency(contents: string): string {
+  if (contents.includes("org.commonmark:commonmark")) {
+    return contents;
+  }
+
+  return contents.replace(
+    /dependencies\s*\{/,
+    `dependencies {
+    ${COMMONMARK_ANDROID_DEPENDENCY}`,
+  );
+}
+
 export const withAndroidNotifications: ConfigPlugin<[string, NotificationMode]> = (
   config,
   [websiteId, mode],
@@ -284,13 +322,8 @@ const withAndroidCoexistence: ConfigPlugin<AndroidNotificationConfig> = (config,
     implementation 'com.google.firebase:firebase-messaging'`,
       );
     }
-    if (!config.modResults.contents.includes("im.crisp:crisp-sdk")) {
-      config.modResults.contents = config.modResults.contents.replace(
-        /dependencies\s*\{/,
-        `dependencies {
-    implementation 'im.crisp:crisp-sdk:2.0.21'`,
-      );
-    }
+    config.modResults.contents = addCrispAndroidSdkDependency(config.modResults.contents);
+    config.modResults.contents = addCommonmarkAndroidDependency(config.modResults.contents);
     return config;
   });
 


### PR DESCRIPTION
## Summary

- Exclude the legacy `com.atlassian.commonmark:commonmark` dependency pulled through the Crisp Android SDK / Markwon stack.
- Add `org.commonmark:commonmark:0.21.0` explicitly so Markwon still has the `org.commonmark.*` classes available even when no other library provides them.
- Apply the same dependency handling in the Android config plugin when it injects Crisp into the generated app module for notification coexistence mode.

## Why

`react-native-purchases-ui` brings `org.commonmark:commonmark:0.21.0`, while `im.crisp:crisp-sdk:2.0.21` brings Markwon, which pulls `com.atlassian.commonmark:commonmark:0.13.0`. Those artifacts use different Maven coordinates, so Gradle keeps both, but both contain the same `org.commonmark.*` classes. Android then fails at `:app:checkDebugDuplicateClasses` with duplicate class errors.

The short-term fix is to replace the legacy CommonMark coordinate with the modern one in the wrapper. This avoids depending on RevenueCat UI to provide CommonMark and keeps the SDK working for apps that do not install RevenueCat.

Closes #26
