### PR TITLE
fix(android): update Crisp SDK to 2.0.23

### DIFF
--- a/.changeset/fix-android-null-link-preview.md
+++ b/.changeset/fix-android-null-link-preview.md
@@ -1,0 +1,5 @@
+---
+"crisp-sdk-react-native": patch
+---
+
+Update the Crisp Android SDK to 2.0.23 to fix a crash when displaying link previews without embedded preview data.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-  implementation("im.crisp:crisp-sdk:2.0.22") {
+  implementation("im.crisp:crisp-sdk:2.0.23") {
     exclude group: "com.atlassian.commonmark", module: "commonmark"
   }
   implementation "org.commonmark:commonmark:0.21.0"

--- a/plugin/src/withAndroid.ts
+++ b/plugin/src/withAndroid.ts
@@ -15,7 +15,7 @@ type AndroidNotificationConfig = {
   mode: NotificationMode;
 };
 
-const CRISP_ANDROID_SDK_DEPENDENCY = `implementation('im.crisp:crisp-sdk:2.0.22') {
+const CRISP_ANDROID_SDK_DEPENDENCY = `implementation('im.crisp:crisp-sdk:2.0.23') {
         exclude group: 'com.atlassian.commonmark', module: 'commonmark'
     }`;
 const COMMONMARK_ANDROID_DEPENDENCY = "implementation 'org.commonmark:commonmark:0.21.0'";


### PR DESCRIPTION
## Summary

- Update the Crisp Android SDK dependency from 2.0.22 to 2.0.23 in the Expo module and config plugin.
- Include the upstream fix for the link-preview crash reported in https://github.com/crisp-im/crisp-sdk-android/issues/238.
- Add a patch changeset for the React Native package.